### PR TITLE
gitignore and makefile for building with cabal and make

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+*.hi
+*.o
+.tests
+jsoncheck
+shellcheck
+dist

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,6 @@ jsoncheck: regardless
 	./test/runQuack && touch .tests
 
 clean:
-	rm -f .tests shellcheck jsoncheck *.hi *.o  ShellCheck/*.hi ShellCheck/*.o
+	rm -f .tests dist shellcheck jsoncheck *.hi *.o  ShellCheck/*.hi ShellCheck/*.o
 
 regardless:


### PR DESCRIPTION
makefile should also delete cabal generated files on cleanup so
they could be used interchangably.

ensure that all generated files are ignored as recommended by
bese practices.
