### PR TITLE
Added cabal setup instructions for Mac OS X to README

### DIFF
--- a/README
+++ b/README
@@ -27,6 +27,9 @@ On Ubuntu and similar, use:
 For older releases, you may have to use:
   apt-get install ghc6 libghc6-parsec3-dev libghc6-quickcheck2-dev libghc6-json-dev libghc-regex-compat-dev cabal-install
 
+On Mac OS X with homebrew (http://brew.sh/), use:
+  brew install cabal-install
+
 Executables can be built with cabal. Tests currently still rely on a Makefile.
 
 Install:


### PR DESCRIPTION
Instructions on getting `cabal` running (with ghc and odd Mac OS X 10.9  + XCode 5 gcc requirement) for non-Haskellites.

Formulating ShellCheck as a homebrew package seems [to have proven problematic](https://github.com/Homebrew/homebrew/pull/21231).
