### PR TITLE
Dynamic linking to libShellCheck

### DIFF
--- a/ShellCheck.cabal
+++ b/ShellCheck.cabal
@@ -9,7 +9,7 @@ Author:           Vidar Holen
 Maintainer:       vidar@vidarholen.net
 Homepage:         http://www.shellcheck.net/
 Build-Type:       Simple
-Cabal-Version:    >= 1.6
+Cabal-Version:    >= 1.8
 Bug-reports:      https://github.com/koalaman/shellcheck/issues
 Description:
   The goals of ShellCheck are:
@@ -44,4 +44,13 @@ library
       ShellCheck.Simple
 
 executable shellcheck
+    build-depends:
+      ShellCheck,
+      base >= 4 && < 5,
+      containers,
+      directory,
+      json,
+      mtl,
+      parsec,
+      regex-compat
     main-is: shellcheck.hs


### PR DESCRIPTION
Hi,

This is a modification of the cabal file for dynamic linking of the executable to the library. It doesn't change anything at development time (since it uses ghc directly), it is rather for distribution packaging.

Dridi
