### PR TITLE
Add cabal update to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ On Mac OS X with MacPorts (http://www.macports.org/):
 
 With cabal installed, cd to the shellcheck source directory and:
 
+    $ cabal update
     $ cabal install
     ...
     $ which shellcheck


### PR DESCRIPTION
Before I ran `cabal update` I got this on `cabal install`

```
Config file path source is default config file.
Config file ~/.cabal/config not found.
Writing default configuration to ~/.cabal/config
Warning: The package list for 'hackage.haskell.org' does not exist. Run 'cabal
update' to download it.
Resolving dependencies...
cabal: Could not resolve dependencies:
trying: ShellCheck-0.3.2
```
