### PR TITLE
Add pandoc to needed dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,12 @@ Text.Regex. To run the unit tests, it also requires QuickCheck2.
 On Fedora, these can be installed with:
 
     yum install ghc ghc-parsec-devel ghc-QuickCheck-devel \
-      ghc-json-devel ghc-regex-compat-devel
+      ghc-json-devel ghc-regex-compat-devel pandoc
 
 On Ubuntu and similar, use:
 
     apt-get install ghc libghc-parsec3-dev libghc-json-dev \
-      libghc-regex-compat-dev libghc-quickcheck2-dev
+      libghc-regex-compat-dev libghc-quickcheck2-dev pandoc
 
 To build and run the tests, cd to the shellcheck source directory and:
 


### PR DESCRIPTION
The pandoc command is needed when compiling with make to run the tests

```
mpereira@ubuntu:~/shellcheck$ make
: Conditionally compiling shellcheck
ghc -O9 --make shellcheck
[1 of 6] Compiling ShellCheck.AST   ( ShellCheck/AST.hs, ShellCheck/AST.o )
[2 of 6] Compiling ShellCheck.Data  ( ShellCheck/Data.hs, ShellCheck/Data.o )
[3 of 6] Compiling ShellCheck.Parser ( ShellCheck/Parser.hs, ShellCheck/Parser.o )
[4 of 6] Compiling ShellCheck.Analytics ( ShellCheck/Analytics.hs, ShellCheck/Analytics.o )
[5 of 6] Compiling ShellCheck.Simple ( ShellCheck/Simple.hs, ShellCheck/Simple.o )
[6 of 6] Compiling Main             ( shellcheck.hs, shellcheck.o )
Linking shellcheck ...
: Running unit tests
./test/runQuack && touch .tests
pandoc -s -t man shellcheck.1.md -o shellcheck.1
make: pandoc: Command not found
make: *** [shellcheck.1] Error 127
```

Once pandoc is installed:

```
mpereira@ubuntu:~/shellcheck$ sudo apt-get install pandoc
mpereira@ubuntu:~/shellcheck$ make
: Conditionally compiling shellcheck
ghc -O9 --make shellcheck
pandoc -s -t man shellcheck.1.md -o shellcheck.1
: Done
```
