### PR TITLE
Using a more complete Haskell .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,15 @@
-*.hi
-*.o
-.tests
-jsoncheck
-shellcheck
-shellcheck.1
+# Created by http://www.gitignore.io
+
+### Haskell ###
 dist
+cabal-dev
+*.o
+*.hi
+*.chi
+*.chs.h
+.virtualenv
+.hsenv
+.cabal-sandbox/
+cabal.sandbox.config
+cabal.config
+


### PR DESCRIPTION
I was using "cabal sandbox", and figured some common Haskell projects artifacts can also be added to the .gitignore.
