### PR TITLE
Collection of HLint fixes

### DIFF
--- a/ShellCheck/Simple.hs
+++ b/ShellCheck/Simple.hs
@@ -28,7 +28,7 @@ import Test.QuickCheck.All (quickCheckAll)
 shellCheck :: String -> [AnalysisOption] -> [ShellCheckComment]
 shellCheck script options =
     let (ParseResult result notes) = parseShell "-" script in
-        let allNotes = notes ++ (concat $ maybeToList $ do
+        let allNotes = notes ++ concat (maybeToList $ do
             (tree, posMap) <- result
             let list = runAnalytics options tree
             return $ map (noteToParseNote posMap) $ filterByAnnotation tree list


### PR DESCRIPTION
I applied [Hlint](http://community.haskell.org/~ndm/hlint/) to the source files and got some source code improvements suggestions.

Most of them are redundant brackets, `do` and `$`.  But there are some nice simplifications as well.
