### PR TITLE
Add extra source files in the source tarball

### DIFF
--- a/ShellCheck.cabal
+++ b/ShellCheck.cabal
@@ -27,8 +27,7 @@ Extra-Source-Files:
     README.md
     shellcheck.1.md
     -- tests
-    test/quackCheck.hs
-    test/runQuack
+    test/shellcheck.hs
     -- misc
     Makefile
 


### PR DESCRIPTION
Hi,

It's been quite a while, and I just noticed that I'm two releases behind. ShellCheck is still at 0.3.1 on Hackage, and I was hoping you'd keep uploading releases there.

This patch will add to the source tarball the missing bits I need to let all the heavy lifting to Fedora's Hackage/Cabal tooling. I will update ShellCheck to 0.3.3 for Fedora soon and I hope I'll build the next release directly from Hackage :-)

Cheers,
Dridi
