### PR TITLE
Adds homebrew installation steps to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,14 +53,14 @@ Let cabal update itself, in case your distro version is outdated:
 With cabal installed, cd to the ShellCheck source directory and:
 
     $ cabal install
-    
+
 This will install ShellCheck to your ~/.cabal/bin directory.
 
 Add the directory to your PATH (for bash, add this to your ~/.bashrc file):
 
     export PATH=$HOME/.cabal/bin:$PATH
 
-Verify that your PATH is set up correctly:    
+Verify that your PATH is set up correctly:
 
     $ which shellcheck
     ~/.cabal/bin/shellcheck


### PR DESCRIPTION
Although this is admittedly trivial, it signals that the package is available on homebrew for OS X. Because the README only discusses building from source I had cloned and built locally before realising I could've simply installed it through brew.
