### PR TITLE
Add a pre-sdist hook to compile the man page (Github issue #247).

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -1,2 +1,43 @@
-import Distribution.Simple
-main = defaultMain
+import Distribution.PackageDescription (
+  HookedBuildInfo,
+  emptyHookedBuildInfo )
+import Distribution.Simple (
+  Args,
+  UserHooks ( preSDist ),
+  defaultMainWithHooks,
+  simpleUserHooks )
+import Distribution.Simple.Setup ( SDistFlags )
+
+-- | This requires the process package from,
+--
+--   https://hackage.haskell.org/package/process
+--
+import System.Process ( callCommand )
+
+
+-- | This will use almost the default implementation, except we switch
+--   out the default pre-sdist hook with our own, 'myPreSDist'.
+--
+main = defaultMainWithHooks myHooks
+  where
+    myHooks = simpleUserHooks { preSDist = myPreSDist }
+
+
+-- | This hook will be executed before e.g. @cabal sdist@. It runs
+--   pandoc to create the man page from shellcheck.1.md. If the pandoc
+--   command is not found, this will fail with an error message:
+--
+--     /bin/sh: pandoc: command not found
+--
+--   Since the man page is listed in the Extra-Source-Files section of
+--   our cabal file, a failure here should result in a failure to
+--   create the distribution tarball (that's a good thing).
+--
+myPreSDist :: Args -> SDistFlags -> IO HookedBuildInfo
+myPreSDist _ _ = do
+  putStrLn "Building the man page..."
+  putStrLn pandoc_cmd
+  callCommand pandoc_cmd
+  return emptyHookedBuildInfo
+  where
+    pandoc_cmd = "pandoc -s -t man shellcheck.1.md -o shellcheck.1"

--- a/ShellCheck.cabal
+++ b/ShellCheck.cabal
@@ -26,6 +26,8 @@ Extra-Source-Files:
     -- documentation
     README.md
     shellcheck.1.md
+    -- built with a cabal sdist hook
+    shellcheck.1
     -- tests
     test/shellcheck.hs
 


### PR DESCRIPTION
This replaces the default preSDist hook in Setup.hs with our own. The
only thing the new hook does is compile the man page using callCommand
from System.Process.

If Pandoc fails, the entire sdist process will fail, since
Extra-Source-Files in the cabal file now lists the man page.

This is preferable to a build hook, because Pandoc pulls in a huge
number of dependencies. It's better to build the man page once and
ship it than to require every user to build and install pandoc before
he can build ShellCheck.

This creates another TODO item: an install hook can now be used to
install the man page along with the rest of ShellCheck. But beware,
the "man path" can vary from system to system.