### PR TITLE
Add a JUnit output format style.

### DIFF
--- a/shellcheck.hs
+++ b/shellcheck.hs
@@ -89,6 +89,7 @@ formats = Map.fromList [
     ("json", forJson),
     ("gcc", forGcc),
     ("checkstyle", forCheckstyle),
+    ("junit", forJunit),
     ("tty", forTty)
     ]
 
@@ -227,6 +228,47 @@ forCheckstyle options files = do
         attr "source" $ "ShellCheck.SC" ++ show (scCode c),
         "/>\n"
         ]
+
+-- JUnit compatible output. A bit of a hack to avoid XML dependencies
+forJunit :: AnalysisOptions -> [FilePath] -> IO Status
+forJunit options files = do
+    putStrLn "<?xml version='1.0' encoding='UTF-8'?>"
+    putStrLn "<testsuites>"
+    statuses <- mapM process files
+    putStrLn "</testsuites>"
+    return $ mconcat statuses
+  where
+    process file = catchExceptions $ do
+        comments <- commentsFor options file
+        putStrLn (formatFile file comments)
+        return $ checkComments comments
+
+    severity "error" = "error"
+    severity "warning" = "warning"
+    severity _ = "info"
+    attr s v = concat [ s, "='", escape v, "' " ]
+    escape = concatMap escape'
+    escape' c = if isOk c then [c] else "&#" ++ show (ord c) ++ ";"
+    isOk x = any ($x) [isAsciiUpper, isAsciiLower, isDigit, (`elem` " ./")]
+
+    formatFile name comments = concat [
+        "<testsuite>\n<properties>\n",
+        "<property ",
+        attr "name" "filename",
+        attr "value" name,
+        "/>\n</properties>\n",
+            concatMap format comments,
+        "</testsuite>"
+        ]
+
+    format c = concat [
+        "<testcase ", attr "time" "0.0", attr "name" $ "ShellCheck.SC" ++ show (scCode c), ">\n",
+        "<failure ",
+        attr "type" $ severity . scSeverity $ c,
+        attr "message" $ "Line " ++ show (scLine c) ++ ", char " ++ show (scColumn c) ++ ": " ++ scMessage c,
+        "/>\n</testcase>\n"
+        ]
+
 
 commentsFor options file = liftM (getComments options) $ readContents file
 


### PR DESCRIPTION
This code is almost entirely based on the checkstyle format code.

The following links were used in putting the output format together:

    https://confluence.atlassian.com/display/BAMBOO/JUnit+parsing+in+Bamboo
    http://stackoverflow.com/questions/4922867/junit-xml-format-specification-that-hudson-supports
    http://windyroad.com.au/dl/Open%20Source/JUnit.xsd

I should probably also mention that I don't know Haskell at all. =)
This just seemed like a straight-forward enough thing to try to do from examples.