### PR TITLE
Add --color switch

### DIFF
--- a/ShellCheck/Checker.hs
+++ b/ShellCheck/Checker.hs
@@ -48,6 +48,7 @@ checkScript sys spec = do
     results <- checkScript (csScript spec)
     return CheckResult {
         crFilename = csFilename spec,
+        crColorOption = csColorOption spec,
         crComments = results
     }
   where

--- a/ShellCheck/Formatter/TTY.hs
+++ b/ShellCheck/Formatter/TTY.hs
@@ -35,7 +35,7 @@ format = return Formatter {
     onResult = outputResult
 }
 
-colorForLevel level = 
+colorForLevel level =
     case level of
         "error"   -> 31 -- red
         "warning" -> 33 -- yellow
@@ -44,7 +44,7 @@ colorForLevel level =
         "message" -> 1 -- bold
         "source"  -> 0 -- none
         otherwise -> 0 -- none
-    
+
 outputError file error = do
     color <- getColorFunc
     hPutStrLn stderr $ color "error" $ file ++ ": " ++ error

--- a/ShellCheck/Formatter/TTY.hs
+++ b/ShellCheck/Formatter/TTY.hs
@@ -46,11 +46,11 @@ colorForLevel level =
         otherwise -> 0 -- none
 
 outputError file error = do
-    color <- getColorFunc
-    hPutStrLn stderr $ color "error" $ file ++ ": " ++ error
+    color <- getColorFunc $ ColorAuto -- FIXME: should respect --color
+    hPutStrLn stderr $ color "error ZZZ" $ file ++ ": " ++ error
 
 outputResult result contents = do
-    color <- getColorFunc
+    color <- getColorFunc $ crColorOption result
     let comments = crComments result
     let fileLines = lines contents
     let lineCount = fromIntegral $ length fileLines
@@ -75,10 +75,15 @@ cuteIndent comment =
 
 code code = "SC" ++ show code
 
-getColorFunc = do
+getColorFunc colorOption = do
     term <- hIsTerminalDevice stdout
     let windows = "mingw" `isPrefixOf` os
-    return $ if term && not windows then colorComment else const id
+    let isUsableTty = term && not windows
+    let useColor = case colorOption of
+                       ColorAlways -> True
+                       ColorNever -> False
+                       ColorAuto -> isUsableTty
+    return $ if useColor then colorComment else const id
   where
     colorComment level comment =
         ansi (colorForLevel level) ++ comment ++ clear

--- a/ShellCheck/Interface.hs
+++ b/ShellCheck/Interface.hs
@@ -34,20 +34,29 @@ data CheckSpec = CheckSpec {
     csFilename :: String,
     csScript :: String,
     csExcludedWarnings :: [Integer],
+    csColorOption :: ColorOptions,
     csShellTypeOverride :: Maybe Shell
 } deriving (Show, Eq)
 
 data CheckResult = CheckResult {
     crFilename :: String,
-    crComments :: [PositionedComment]
+    crComments :: [PositionedComment],
+    crColorOption :: ColorOptions
 } deriving (Show, Eq)
 
 emptyCheckSpec = CheckSpec {
     csFilename = "",
     csScript = "",
     csExcludedWarnings = [],
-    csShellTypeOverride = Nothing
+    csShellTypeOverride = Nothing,
+    csColorOption = ColorAuto
 }
+
+data ColorOptions =
+    ColorAuto
+    | ColorAlways
+    | ColorNever
+  deriving (Ord, Eq, Show)
 
 -- Parser input and output
 data ParseSpec = ParseSpec {

--- a/shellcheck.hs
+++ b/shellcheck.hs
@@ -59,7 +59,8 @@ instance Monoid Status where
 
 data Options = Options {
     checkSpec :: CheckSpec,
-    externalSources :: Bool
+    externalSources :: Bool,
+    color :: ColorOptions
 }
 
 defaultOptions = Options {
@@ -73,6 +74,8 @@ options = [
         (ReqArg (Flag "exclude") "CODE1,CODE2..") "exclude types of warnings",
     Option "f" ["format"]
         (ReqArg (Flag "format") "FORMAT") "output format",
+    Option "C" ["color"]
+        (ReqArg (Flag "color") "WHEN") "Set use of color (auto, always, never)",
     Option "s" ["shell"]
         (ReqArg (Flag "shell") "SHELLNAME") "Specify dialect (sh,bash,dash,ksh)",
     Option "x" ["external-sources"]
@@ -195,6 +198,13 @@ runFormatter sys format options files = do
             then NoProblems
             else SomeProblems
 
+parseColorOption colorOption =
+    case colorOption of
+        "auto" -> ColorAuto
+        "always" -> ColorAlways
+        "never" -> ColorNever
+        _ -> error $ "Bad value for --color `" ++ colorOption ++ "'"
+
 parseOption flag options =
     case flag of
         Flag "shell" str ->
@@ -222,6 +232,13 @@ parseOption flag options =
         Flag "externals" _ ->
             return options {
                 externalSources = True
+            }
+
+        Flag "color" color ->
+            return options {
+                checkSpec = (checkSpec options) {
+                    csColorOption = parseColorOption color
+                }
             }
 
         _ -> return options

--- a/shellcheck.hs
+++ b/shellcheck.hs
@@ -76,7 +76,7 @@ options = [
         (ReqArg (Flag "format") "FORMAT") "output format",
     Option "C" ["color"]
         (OptArg (maybe (Flag "color" "always") (Flag "color")) "WHEN")
-        "Set use of color (auto, always, never)",
+        "Use color (auto, always, never)",
     Option "s" ["shell"]
         (ReqArg (Flag "shell") "SHELLNAME") "Specify dialect (sh,bash,dash,ksh)",
     Option "x" ["external-sources"]

--- a/shellcheck.hs
+++ b/shellcheck.hs
@@ -75,7 +75,8 @@ options = [
     Option "f" ["format"]
         (ReqArg (Flag "format") "FORMAT") "output format",
     Option "C" ["color"]
-        (ReqArg (Flag "color") "WHEN") "Set use of color (auto, always, never)",
+        (OptArg (maybe (Flag "color" "always") (Flag "color")) "WHEN")
+        "Set use of color (auto, always, never)",
     Option "s" ["shell"]
         (ReqArg (Flag "shell") "SHELLNAME") "Specify dialect (sh,bash,dash,ksh)",
     Option "x" ["external-sources"]


### PR DESCRIPTION
Add --color switch

This changeset adds a --color switch to `shellcheck`. It works in a
similar fashion to the option of the same name in GNU tools such as
`ls`:

* `--color` or, equivalently, `--color=always` prints text
  using color codes, even if stdout is not a terminal;

* `--color=never` disables color;

* `--color=auto`, the same as not specifying a `--color` option at
  all, will print in color when stdout is deemed to be a capable
  terminal.

This switch is useful when using, for example, a color-aware pager:
one can use `shellcheck --color | less -R` to get scrollable, colored
text, whereas `shellcheck` would otherwise print without color codes.

Comments on the code are very welcome; I don't know how well this fits
in the existing codebase, etc. Also I didn't add any tests, although
it certainly would make sense to do so.

# Requesting a pull to haguenau:master from haguenau:add-color-switch
#
# Write a message for this pull request. The first block
# of text is the title and the rest is description.
#
# Changes:
#
# 0044c3d (David Haguenauer, 16 minutes ago)
#    Make use of --color with no argument equivalent to --color=always
#
# a3d4101 (David Haguenauer, 24 hours ago)
#    Add initial support for --color
#
# bd359c5 (David Haguenauer, 24 hours ago)
#    Delete trailing whitespace
