### PR TITLE
add compilation documentation for test runners

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ Verify that `cabal` is installed and update its dependency list with
 
     $ cabal install
 
+Or if you intend to run the tests:
+
+    $ cabal install --enable-tests
+
 This will compile ShellCheck and install it to your `~/.cabal/bin` directory.
 
 Add this directory to your `PATH` (for bash, add this to your `~/.bashrc`):


### PR DESCRIPTION
Super minor documentation update, but for first-time cabal users we can avoid needing to compile twice because 'cabal test' won't run the first time we try.
