### PR TITLE
Make SC1035 emit an end column

### DIFF
--- a/ShellCheck/Checker.hs
+++ b/ShellCheck/Checker.hs
@@ -39,7 +39,7 @@ import Test.QuickCheck.All
 
 tokenToPosition map (TokenComment id c) = fromMaybe fail $ do
     position <- Map.lookup id map
-    return $ PositionedComment position c
+    return $ PositionedComment position position c
   where
     fail = error "Internal shellcheck error: id doesn't exist. Please report!"
 
@@ -65,13 +65,13 @@ checkScript sys spec = do
         return . nub . sortMessages . filter shouldInclude $
             (parseMessages ++ map translator analysisMessages)
 
-    shouldInclude (PositionedComment _ (Comment _ code _)) =
+    shouldInclude (PositionedComment _ _ (Comment _ code _)) =
         code `notElem` csExcludedWarnings spec
 
     sortMessages = sortBy (comparing order)
-    order (PositionedComment pos (Comment severity code message)) =
+    order (PositionedComment pos _ (Comment severity code message)) =
         (posFile pos, posLine pos, posColumn pos, severity, code, message)
-    getPosition (PositionedComment pos _) = pos
+    getPosition (PositionedComment pos _ _) = pos
 
     analysisSpec root =
         AnalysisSpec {
@@ -84,7 +84,7 @@ getErrors sys spec =
     sort . map getCode . crComments $
         runIdentity (checkScript sys spec)
   where
-    getCode (PositionedComment _ (Comment _ code _)) = code
+    getCode (PositionedComment _ _ (Comment _ code _)) = code
 
 check = checkWithIncludes []
 

--- a/ShellCheck/Formatter/JSON.hs
+++ b/ShellCheck/Formatter/JSON.hs
@@ -37,10 +37,11 @@ format = do
     }
 
 instance JSON (PositionedComment) where
-  showJSON comment@(PositionedComment pos (Comment level code string)) = makeObj [
-      ("file", showJSON $ posFile pos),
-      ("line", showJSON $ posLine pos),
-      ("column", showJSON $ posColumn pos),
+  showJSON comment@(PositionedComment start end (Comment level code string)) = makeObj [
+      ("file", showJSON $ posFile start),
+      ("line", showJSON $ posLine start),
+      ("column", showJSON $ posColumn start),
+      ("endColumn", showJSON $ posColumn end),
       ("level", showJSON $ severityText comment),
       ("code", showJSON code),
       ("message", showJSON string)

--- a/ShellCheck/Interface.hs
+++ b/ShellCheck/Interface.hs
@@ -94,7 +94,7 @@ data Position = Position {
 } deriving (Show, Eq)
 
 data Comment = Comment Severity Code String deriving (Show, Eq)
-data PositionedComment = PositionedComment Position Comment deriving (Show, Eq)
+data PositionedComment = PositionedComment Position Position Comment deriving (Show, Eq)
 data TokenComment = TokenComment Id Comment deriving (Show, Eq)
 
 data ColorOption =

--- a/ShellCheck/Parser.hs
+++ b/ShellCheck/Parser.hs
@@ -814,7 +814,7 @@ readCondition = called "test expression" $ do
     pos <- getPosition
     space <- allspacing
     when (null space) $
-        parseProblemAt pos ErrorC 1035 $ "You need a space after the " ++
+        parseProblemAtWithEnd opos pos ErrorC 1035 $ "You need a space after the " ++
             if single
                 then "[ and before the ]."
                 else "[[ and before the ]]."


### PR DESCRIPTION
This change makes PositionedComment and ParseNote contain end columns.
It additionally modifies the JSON formatter to show the end column in an
"endColumn" property. SC1035 is then modified to set this end column.

Currently, all other checks set the end column to the start column.
Additional work is needed to set the end column during AST analysis.