### PR TITLE
Emit the end line in the JSON

### DIFF
--- a/ShellCheck/Formatter/JSON.hs
+++ b/ShellCheck/Formatter/JSON.hs
@@ -40,6 +40,7 @@ instance JSON (PositionedComment) where
   showJSON comment@(PositionedComment start end (Comment level code string)) = makeObj [
       ("file", showJSON $ posFile start),
       ("line", showJSON $ posLine start),
+      ("endLine", showJSON $ posLine end),
       ("column", showJSON $ posColumn start),
       ("endColumn", showJSON $ posColumn end),
       ("level", showJSON $ severityText comment),


### PR DESCRIPTION
This handles the case where the end line is not on the same line as the
start line when using the new end column feature.