### PR TITLE
Properly set the end column for SC2086 findings

### DIFF
--- a/ShellCheck/Interface.hs
+++ b/ShellCheck/Interface.hs
@@ -58,6 +58,7 @@ data ParseSpec = ParseSpec {
 data ParseResult = ParseResult {
     prComments :: [PositionedComment],
     prTokenPositions :: Map.Map Id Position,
+    prTokenEndPositions :: Map.Map Id Position,
     prRoot :: Maybe Token
 } deriving (Show, Eq)
 


### PR DESCRIPTION
This change makes the architectural changes needed to support emitting
end columns in AST based analyzers. As a first check, it emits a correct
end column in SC2086.
