### PR TITLE
add Dockerfile that will build shellcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:xenial
+MAINTAINER https://github.com/koalaman/shellcheck
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    cabal-install \
+    ghc \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY ShellCheck.cabal /src/ShellCheck.cabal
+
+WORKDIR /src
+
+ENV PATH="/root/.cabal/bin:$PATH"
+
+RUN cabal update \
+ && cabal install --only-dependencies
+
+COPY . /src
+
+RUN cabal install /src
+
+CMD ["shellcheck", "-"]


### PR DESCRIPTION
Similar to #720 but will build from the current source.  Run with docker run -i shellcheck < /path/to/script