### PR TITLE
Add CI/CD solution with Docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+sudo: required
+
+language: sh
+
+services:
+  - docker
+
+before_install:
+  - export DOCKER_REPO=nlknguyen/shellcheck
+  - export TAG=$(if [ "$TRAVIS_BRANCH" == "master" ]; then echo "latest"; else echo $TRAVIS_BRANCH ; fi)  
+
+script:
+  - docker build -t builder -f Dockerfile_builder .
+  - docker run --rm -it -v $(pwd):/mnt builder
+  - docker build -t $DOCKER_REPO:$TAG .
+
+after_success:
+  - docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
+  - docker push $DOCKER_REPO:$TAG

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
   - docker
 
 before_install:
-  - export DOCKER_REPO=nlknguyen/shellcheck
+  - export DOCKER_REPO=koalaman/shellcheck
   - |-
     export TAG=$([ "$TRAVIS_BRANCH" == "master" ] && echo "latest" || echo $TRAVIS_BRANCH)
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ services:
 
 before_install:
   - export DOCKER_REPO=nlknguyen/shellcheck
-  - export TAG=$([ "$TRAVIS_BRANCH" == "master" ] && echo "latest" || echo $TRAVIS_BRANCH) 
+  - |-
+    export TAG=$([ "$TRAVIS_BRANCH" == "master" ] && echo "latest" || echo $TRAVIS_BRANCH)
 
 script:
   - docker build -t builder -f Dockerfile_builder .
@@ -16,6 +17,5 @@ script:
 
 after_success:
   - docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
-  - if [ "$TRAVIS_BRANCH" == "master" ]; then \
-      docker push $DOCKER_REPO:$TAG           \
-    fi
+  - |-
+    [ "$TRAVIS_BRANCH" == "master" ] && docker push $DOCKER_REPO:$TAG

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 
 before_install:
   - export DOCKER_REPO=nlknguyen/shellcheck
-  - export TAG=$([ "$TRAVIS_BRANCH" == "master" ] && echo "latest" || echo $TRAVIS_BRANCH)
+  - export TAG=$([ "$TRAVIS_BRANCH" == "master" ] && echo "latest" || echo $TRAVIS_BRANCH) 
 
 script:
   - docker build -t builder -f Dockerfile_builder .
@@ -16,5 +16,6 @@ script:
 
 after_success:
   - docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
-  - [ "$TRAVIS_BRANCH" == "master" ] && docker push $DOCKER_REPO:$TAG 
-  # Only push to Docker Hub if this is the master branch 
+  - if [ "$TRAVIS_BRANCH" == "master" ]; then \
+      docker push $DOCKER_REPO:$TAG           \
+    fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ services:
 
 before_install:
   - export DOCKER_REPO=nlknguyen/shellcheck
-  - export TAG=$(if [ "$TRAVIS_BRANCH" == "master" ]; then echo "latest"; else echo $TRAVIS_BRANCH ; fi)  
+  - export TAG=$([ "$TRAVIS_BRANCH" == "master" ] && echo "latest" || echo $TRAVIS_BRANCH)
 
 script:
   - docker build -t builder -f Dockerfile_builder .
@@ -16,4 +16,5 @@ script:
 
 after_success:
   - docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
-  - docker push $DOCKER_REPO:$TAG
+  - [ "$TRAVIS_BRANCH" == "master" ] && docker push $DOCKER_REPO:$TAG 
+  # Only push to Docker Hub if this is the master branch 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,11 @@
-FROM ubuntu:xenial
-MAINTAINER https://github.com/koalaman/shellcheck
+FROM alpine:latest
 
-RUN apt-get update && apt-get install --no-install-recommends -y \
-    cabal-install \
-    ghc \
- && rm -rf /var/lib/apt/lists/*
+MAINTAINER Nikyle Nguyen <NLKNguyen@MSN.com>
 
-COPY ShellCheck.cabal /src/ShellCheck.cabal
+COPY package/bin/shellcheck /usr/local/bin/
+COPY package/lib/           /usr/local/lib/
 
-WORKDIR /src
+RUN ldconfig /usr/local/lib
 
-ENV PATH="/root/.cabal/bin:$PATH"
-
-RUN cabal update \
- && cabal install --only-dependencies
-
-COPY . /src
-
-RUN cabal install /src
-
-CMD ["shellcheck", "-"]
+WORKDIR /mnt
+ENTRYPOINT ["shellcheck"]

--- a/Dockerfile_builder
+++ b/Dockerfile_builder
@@ -1,0 +1,53 @@
+FROM mitchty/alpine-ghc:latest
+
+MAINTAINER Nikyle Nguyen <NLKNguyen@MSN.com>
+
+RUN apk add --no-cache build-base
+
+RUN mkdir -p /usr/src/shellcheck
+WORKDIR /usr/src/shellcheck
+
+# # ------------------------------------------------------------
+# # Build & Test
+# # ------------------------------------------------------------
+
+# Obtain the dependencies first, which are less likely to change, in order to reduce
+# subsequent build time by leveraging image cache. This benefits developers when they
+# build their code with this image locally. In case of Travis CI, this doesn't help
+# reduce building time because Travis CI doesn't use cache.
+COPY ShellCheck.cabal .
+RUN cabal update && cabal install --only-dependencies
+
+# Copy the rest of the source files, including ShellCheck.cabal again but doesn't matter
+COPY . .
+
+# Build
+RUN cabal install
+
+# TODO: run tests
+
+# # ------------------------------------------------------------
+# # Set PATH
+# # ------------------------------------------------------------
+
+# Add runtime path to easily reach the executable file. This only exists during build.
+ENV PATH "/root/.cabal/bin:$PATH"
+
+# Make it permanent for someone who login to the container of this image
+RUN echo "export PATH=${PATH}" >>  /etc/profile
+
+# # ------------------------------------------------------------
+# # Extract Binaries
+# # ------------------------------------------------------------
+
+# Get shellcheck binary
+RUN mkdir -p /package/bin/
+RUN cp $(which shellcheck) /package/bin/
+
+# Get shared libraries using magic
+RUN mkdir -p /package/lib/
+RUN ldd $(which shellcheck) | grep "=> /" | awk '{print $3}' | xargs -I '{}' cp -v '{}' /package/lib/
+
+
+# Copy shellcheck package out to mounted directory
+CMD ["cp", "-avr", "/package", "/mnt/"]

--- a/Dockerfile_builder
+++ b/Dockerfile_builder
@@ -24,7 +24,8 @@ COPY . .
 # Build
 RUN cabal install
 
-# TODO: run tests
+# Test
+RUN cabal test
 
 # # ------------------------------------------------------------
 # # Set PATH


### PR DESCRIPTION
Provide Continuous Integration & Continuous Delivery solution to this repository.

The changes include:

- **./Dockerfile_builder** is used to build shellcheck from source and collect executable shellcheck binary and object dependencies into a directory for easy retrieval. When it runs, the binaries will be copied out to the mounted directory.

- **./Dockerfile** is used to build the image that is based on `alpine:latest` and contains only the neccessary binaries for shellcheck to run. The entry point of the image is shellcheck program, and `/mnt` is the designated mount point when using this image as a CLI program.

- **./.travis.yml** Travis CI build script. The commit to this repo will trigger the build process, so we will know if it succeeds or fails. If the build succeeds, the final, lightweight Docker image will be pushed to Docker Hub automatically under your Docker Hub repo and credentials. Changes on every branch will trigger the build, but only Docker image built in master branch will be pushed to Docker Hub with `latest` tag.

References:
- https://github.com/NLKNguyen/alpine-shellcheck
- https://hub.docker.com/r/nlknguyen/alpine-shellcheck/