### PR TITLE
Push git tags to dockerhub as docker tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ services:
 before_install:
   - export DOCKER_REPO=koalaman/shellcheck
   - |-
-    export TAG=$([ "$TRAVIS_BRANCH" == "master" ] && echo "latest" || echo $TRAVIS_BRANCH)
+    export TAG=$([ "$TRAVIS_BRANCH" == "master" ] && echo "latest" || ([ -n "$TRAVIS_TAG" ] && echo "$TRAVIS_TAG") || echo "$TRAVIS_BRANCH")
 
 script:
   - docker build -t builder -f Dockerfile_builder .
@@ -18,4 +18,4 @@ script:
 after_success:
   - docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
   - |-
-    [ "$TRAVIS_BRANCH" == "master" ] || (! [ -z "$TRAVIS_TAG" ] && [ "$TRAVIS_TAG" == "$TAG" ]) && docker push $DOCKER_REPO:$TAG
+    ([ "$TRAVIS_BRANCH" == "master" ] || [ -n "$TRAVIS_TAG" ]) && docker push "$DOCKER_REPO:$TAG"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ script:
 after_success:
   - docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
   - |-
-    [ "$TRAVIS_BRANCH" == "master" ] && docker push $DOCKER_REPO:$TAG
+    [ "$TRAVIS_BRANCH" == "master" ] || (! [ -z "$TRAVIS_TAG" ] && [ "$TRAVIS_TAG" == "$TAG" ]) && docker push $DOCKER_REPO:$TAG


### PR DESCRIPTION
It is nice that shellcheck has a Docker distribution now since #734 was merged. It is useful in some environments, for instance when using shellcheck in Travis builds.
As far as I can understand, it looks like the current setup will only push the latest build of HEAD of the master branch to the `latest` tag in Dockerhub though. I think it would be useful if the releases were also tagged in Dockerhub so that you can point to a release version when using the Docker distribution of shellcheck e.g. `docker run koalaman/shellcheck:v0.4.5`.

This change *should* do just that, but it is a bit difficult to test. :) 
It looks like Travis will set `$TRAVIS_TAG='git_tag'` and `$TRAVIS_BRANCH='git_tag'` if the build was initiated by pushing a tag to the git repo. (see https://docs.travis-ci.com/user/environment-variables/) So the rationale is that we check for both of those being set to to the same thing and push `$TAG` to dockerhub if that is the case.