### PR TITLE
SC2164: show two possible variants for circumenting the warning

### DIFF
--- a/ShellCheck/Analytics.hs
+++ b/ShellCheck/Analytics.hs
@@ -2514,7 +2514,7 @@ checkUncheckedCd params root =
         when(t `isUnqualifiedCommand` "cd"
             && not (isCdDotDot t)
             && not (isCondition $ getPath (parentMap params) t)) $
-                warn (getId t) 2164 "Use cd ... || exit in case cd fails."
+                warn (getId t) 2164 "Use 'cd ... || exit' or 'cd ... || return' in case cd fails."
     checkElement _ = return ()
     isCdDotDot t = oversimplify t == ["cd", ".."]
     hasSetE = isNothing $ doAnalysis (guard . not . isSetE) root


### PR DESCRIPTION
always calling 'exit' is not good in e.g. functions.
the basic idea is at least that the returncode of
cd *is* evaluated somehow and not ignored.

Reported-by: Garance Alistair Drosehn <drosehn@rpi.edu>

Signed-off-by: Bastian Bittorf <bittorf@bluebottle.com>