### PR TITLE
Failing test: SC2029 is triggered with 'ssh -o Foo=bar "$host"'

### DIFF
--- a/ShellCheck/Checks/Commands.hs
+++ b/ShellCheck/Checks/Commands.hs
@@ -462,6 +462,7 @@ checkInteractiveSu = CommandCheck (Basename "su") f
 prop_checkSshCmdStr1 = verify checkSshCommandString "ssh host \"echo $PS1\""
 prop_checkSshCmdStr2 = verifyNot checkSshCommandString "ssh host \"ls foo\""
 prop_checkSshCmdStr3 = verifyNot checkSshCommandString "ssh \"$host\""
+prop_checkSshCmdStr4 = verifyNot checkSshCommandString "ssh -o TCPKeepAlive=no \"$host\""
 checkSshCommandString = CommandCheck (Basename "ssh") (f . arguments)
   where
     nonOptions =


### PR DESCRIPTION
I assume that this serves as a failing test?!

```sh
host=foo
ssh -o Foo=bar "$host"
```