### PR TITLE
Fix incorrect detection of bash-style substring expansion (issue #950)

### DIFF
--- a/ShellCheck/AnalyzerLib.hs
+++ b/ShellCheck/AnalyzerLib.hs
@@ -623,7 +623,7 @@ getOffsetReferences mods = fromMaybe [] $ do
     offsets <- match !!! 0
     return $ matchAllStrings variableNameRegex offsets
   where
-    re = mkRegex "^ *:(.*)"
+    re = mkRegex "^ *:([^-=?+].*)"
 
 getReferencedVariables parents t =
     case t of


### PR DESCRIPTION
Substring expansion detection only considers ':' as a separator..  It
needs to avoid triggering for ":-", ":=", ":+" and ":?", since they
mean other things.

This is a regression introduced by commit
a90b6d14b3de0f21db462afbc925444687feb2ca

Signed-off-by: Martin Schwenke <martin@meltin.net>