### PR TITLE
Documented binary cabal install for MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,12 @@ This section describes how to build ShellCheck from a source directory. ShellChe
 
 ShellCheck is built and packaged using Cabal. Install the package `cabal-install` from your system's package manager (with e.g. `apt-get`, `brew`, `emerge`, `yum`, or `zypper`).
 
+On MacOS (OS X), you can do a fast install of Cabal using brew, which takes a couple of minutes instead of more than 30 minutes if you try to compile it from source.
+
+    brew install cask
+    brew cask install haskell-platform
+    cabal install cabal-install
+
 On MacPorts, the package is instead called `hs-cabal-install`, while native Windows users should install the latest version of the Haskell platform from https://www.haskell.org/platform/
 
 Verify that `cabal` is installed and update its dependency list with


### PR DESCRIPTION
Installing haskell binaries is 50x faster than compiling it from source.