### PR TITLE
SC2154: Fix false positive on `local`

### DIFF
--- a/ShellCheck/ASTLib.hs
+++ b/ShellCheck/ASTLib.hs
@@ -329,7 +329,8 @@ getAssociativeArrays t =
     f :: Token -> Writer [String] ()
     f t@T_SimpleCommand {} = fromMaybe (return ()) $ do
         name <- getCommandName t
-        guard $ name == "declare" || name == "typeset"
+        let assocNames = ["declare","local","typeset"]
+        guard $ elem name assocNames
         let flags = getAllFlags t
         guard $ elem "A" $ map snd flags
         let args = map fst . filter ((==) "" . snd) $ flags


### PR DESCRIPTION
Test file:

```
$ cat test.sh
#!/usr/bin/bash

function arrDeclare() {
  declare -A arrd
  arrd[foo]=bar
  echo "${arrd[*]}"
}
function arrLocal() {
  local -A arrl
  arrl[fool]=bar
  echo "${arrl[*]}"
}
function arrTypeset() {
  typeset -A arrt
  arrt[foot]=bar
  echo "${arrt[*]}"
}
```

Before this fix:

```
$shellcheck test.sh

In test.sh line 10:
  arrl[fool]=bar
       ^-- SC2154: fool is referenced but not assigned.
```

After this fix:

```
$shellcheck test.sh
```

Fixes koalaman/shellcheck#953

P.S. I'm not very familiar with the test frameworks or with Haskell, so I did not add any tests for these additional cases. I'll happily accept guidance to where and how that should be done!