### PR TITLE
build and publish alpine based docker images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,12 +24,17 @@ script:
   - rm -rf dist || true
   # Linux Docker image
   - docker build -t "$DOCKER_REPO:$TAG" .
+  # Linux Docker Alpine image
+  - sed -i 's|FROM scratch|FROM alpine:latest|' Dockerfile
+  - docker build -t "$DOCKER_REPO:$TAG-alpine" .
 
 after_success:
   - ./.prepare_deploy
   - docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
   - |-
     ([ "$TRAVIS_BRANCH" == "master" ] || [ -n "$TRAVIS_TAG" ]) && docker push "$DOCKER_REPO:$TAG"
+  - |-
+    ([ "$TRAVIS_BRANCH" == "master" ] || [ -n "$TRAVIS_TAG" ]) && docker push "$DOCKER_REPO:$TAG-alpine"
 
 after_failure:
   - id


### PR DESCRIPTION
This PR adds an alpine based image to the docker hub. Commit 21f5bf01ebfde23a428c0a154e05d2468a11a00c changed the alpine based images to an image based on scratch which I find to be less useful than previous. This commit mimics official docker images by appending `-alpine` to the tag for alpine based images.

I'd really like to have this feature in since I'm using `shellcheck` in my https://github.com/drone/drone based ci pipeline and providing the files as globs. This used to work for me:
```yml
shellcheck:
    image: koalaman/shellcheck
    commands:
      - shellcheck installer/*.sh ci/*.sh
      - cd docker/scripts
      - shellcheck -x *.sh
```
I am working around the new image by adding a step to my pipeline to build an alpine based container and then use it in a later step. This is also problematic because I am verifying the hash matches what is embedded in the Dockerfile, which becomes out of date pretty regularly.

I don't think editing the Dockerfile will be a problem, nothing seems to check repo "dirty" status and this way there is only every 1 file to maintain.