### PR TITLE
Add a pre-commit config so shellcheck can be used as a pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,8 @@
+- id: shellcheck
+  name: shellcheck
+  description: |
+    A static analysis tool for shell scripts
+    https://www.shellcheck.net
+  entry: koalaman/shellcheck
+  language: docker_image
+  types: [shell]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,6 +3,15 @@
   description: |
     A static analysis tool for shell scripts
     https://www.shellcheck.net
-  entry: koalaman/shellcheck
+  entry: koalaman/shellcheck:stable
+  language: docker_image
+  types: [shell]
+
+- id: shellcheck_latest
+  name: shellcheck-latest
+  description: |
+    A static analysis tool for shell scripts - latest tag
+    https://www.shellcheck.net
+  entry: koalaman/shellcheck:latest
   language: docker_image
   types: [shell]


### PR DESCRIPTION
I'd like to use shellcheck as a pre-commit hook for some shell script projects. To use this hook in a repo, create a `.pre-commit-config.yaml` in the repo root with the following, then run `pre-commit install --install-hooks`.

```
repos:
  - repo: https://github.com/koalaman/shellcheck
    sha: v0.4.7 # or whatever tag this change is release in
    hooks:
      - id: shellcheck
```

Seems to work great!