### PR TITLE
Fix isClosingFileOp (fixes issue #862)

### DIFF
--- a/ShellCheck/Analytics.hs
+++ b/ShellCheck/Analytics.hs
@@ -1810,6 +1810,7 @@ prop_checkUnused33= verifyNotTree checkUnusedAssignments "a=foo; [[ foo =~ ^{$a}
 prop_checkUnused34= verifyNotTree checkUnusedAssignments "foo=1; (( t = foo )); echo $t"
 prop_checkUnused35= verifyNotTree checkUnusedAssignments "a=foo; b=2; echo ${a:b}"
 prop_checkUnused36= verifyNotTree checkUnusedAssignments "if [[ -v foo ]]; then true; fi"
+prop_checkUnused37= verifyNotTree checkUnusedAssignments "fd=2; exec {fd}>&-"
 checkUnusedAssignments params t = execWriter (mapM_ warnFor unused)
   where
     flow = variableFlow params

--- a/ShellCheck/AnalyzerLib.hs
+++ b/ShellCheck/AnalyzerLib.hs
@@ -487,8 +487,8 @@ getModifiedVariables t =
 
 isClosingFileOp op =
     case op of
-        T_IoFile _ (T_GREATAND _) (T_NormalWord _ [T_Literal _ "-"]) -> True
-        T_IoFile _ (T_LESSAND  _) (T_NormalWord _ [T_Literal _ "-"]) -> True
+        T_IoDuplicate _ (T_GREATAND _) "-" -> True
+        T_IoDuplicate _ (T_LESSAND  _) "-" -> True
         _ -> False
 
 


### PR DESCRIPTION
The isClosingFileOp function expected closing file ops to use T_IoFile, but
they actually use T_IoDuplicate; so it effectively always returned False.

This fixes issue #862.