### PR TITLE
Add snapcraft.yaml to build snap package

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,37 @@
+name: shellcheck
+summary: A shell script static analysis tool
+description: |
+  ShellCheck is a GPLv3 tool that gives warnings and suggestions for bash/sh
+  shell scripts.
+
+  The goals of ShellCheck are
+
+  - To point out and clarify typical beginner's syntax issues that cause a
+    shell to give cryptic error messages.
+
+  - To point out and clarify typical intermediate level semantic problems that
+    cause a shell to behave strangely and counter-intuitively.
+
+  - To point out subtle caveats, corner cases and pitfalls that may cause an
+    advanced user's otherwise working script to fail under future
+    circumstances.
+version: git
+grade: stable
+confinement: classic
+
+apps:
+  shellcheck:
+    command: usr/bin/shellcheck
+
+parts:
+  shellcheck:
+    plugin: dump
+    source: ./
+    build-packages:
+      - cabal-install
+    build: |
+      cabal sandbox init
+      cabal install -j
+    install: |
+      install -d $SNAPCRAFT_PART_INSTALL/usr/bin
+      install .cabal-sandbox/bin/shellcheck $SNAPCRAFT_PART_INSTALL/usr/bin


### PR DESCRIPTION
This adds configuration to build a snap package (https://snapcraft.io/)

To build, run `snapcraft` from the base directory.
The resulting snap can be installed with `sudo snap install --dangerous --classic <snapfile>`