### PR TITLE
SC2029: Skip when there are options to ssh

### DIFF
--- a/ShellCheck/Checks/Commands.hs
+++ b/ShellCheck/Checks/Commands.hs
@@ -482,6 +482,7 @@ checkInteractiveSu = CommandCheck (Basename "su") f
 prop_checkSshCmdStr1 = verify checkSshCommandString "ssh host \"echo $PS1\""
 prop_checkSshCmdStr2 = verifyNot checkSshCommandString "ssh host \"ls foo\""
 prop_checkSshCmdStr3 = verifyNot checkSshCommandString "ssh \"$host\""
+prop_checkSshCmdStr4 = verifyNot checkSshCommandString "ssh -i key \"$host\""
 checkSshCommandString = CommandCheck (Basename "ssh") (f . arguments)
   where
     nonOptions =

--- a/ShellCheck/Checks/Commands.hs
+++ b/ShellCheck/Checks/Commands.hs
@@ -485,11 +485,10 @@ prop_checkSshCmdStr3 = verifyNot checkSshCommandString "ssh \"$host\""
 prop_checkSshCmdStr4 = verifyNot checkSshCommandString "ssh -i key \"$host\""
 checkSshCommandString = CommandCheck (Basename "ssh") (f . arguments)
   where
-    nonOptions =
-        filter (\x -> not $ "-" `isPrefixOf` concat (oversimplify x))
+    isOption x = "-" `isPrefixOf` (concat $ oversimplify x)
     f args =
-        case nonOptions args of
-            (hostport:r@(_:_)) -> checkArg $ last r
+        case partition isOption args of
+            ([], hostport:r@(_:_)) -> checkArg $ last r
             _ -> return ()
     checkArg (T_NormalWord _ [T_DoubleQuoted id parts]) =
         case filter (not . isConstant) parts of


### PR DESCRIPTION
Fixes #327

SC2029 generates false positives when given an ssh command that includes
options with arguments because it assumes the first non-option must be the
host:port argument and the last argument is a command to run.
As suggested the comments on #327, this change fixes those by skipping the
check when there are any options present.