### PR TITLE
Add test for `local` keyword in SC2154

### DIFF
--- a/ShellCheck/Analytics.hs
+++ b/ShellCheck/Analytics.hs
@@ -1879,6 +1879,7 @@ prop_checkUnassignedReferences29= verifyNotTree checkUnassignedReferences "if [[
 prop_checkUnassignedReferences30= verifyNotTree checkUnassignedReferences "if [[ -v foo[3] ]]; then echo ${foo[3]}; fi"
 prop_checkUnassignedReferences31= verifyNotTree checkUnassignedReferences "X=1; if [[ -v foo[$X+42] ]]; then echo ${foo[$X+42]}; fi"
 prop_checkUnassignedReferences32= verifyNotTree checkUnassignedReferences "if [[ -v \"foo[1]\" ]]; then echo ${foo[@]}; fi"
+prop_checkUnassignedReferences33= verifyNotTree checkUnassignedReferences "f() { local -A foo; echo \"${foo[@]}\"; }"
 checkUnassignedReferences params t = warnings
   where
     (readMap, writeMap) = execState (mapM tally $ variableFlow params) (Map.empty, Map.empty)


### PR DESCRIPTION
I felt bad about not adding a test for this in my original PR, so this should cover that behavior.

Follow-up to koalaman/shellcheck#988