### PR TITLE
MacOS support for nextnumber

### DIFF
--- a/nextnumber
+++ b/nextnumber
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # TODO: Find a less trashy way to get the next available error code
 if ! shopt -s globstar
 then

--- a/nextnumber
+++ b/nextnumber
@@ -1,7 +1,10 @@
 #!/bin/bash
 # TODO: Find a less trashy way to get the next available error code
-
-shopt -s globstar
+if ! shopt -s globstar
+then
+  echo "Error: This script depends on Bash 4." >&2
+  exit 1
+fi
 
 for i in 1 2
 do


### PR DESCRIPTION
Allows the use of the homebrew installed Bash 4 on MacOS systems. It
should compatible with most if not all modern Linux distros.