### PR TITLE
Add custom-setup stanza and containers lowerbound

### DIFF
--- a/ShellCheck.cabal
+++ b/ShellCheck.cabal
@@ -31,6 +31,12 @@ Extra-Source-Files:
     -- tests
     test/shellcheck.hs
 
+custom-setup
+  setup-depends:
+    base    >= 4    && <5,
+    process >= 1.0  && <1.7,
+    Cabal   >= 1.10 && <2.3
+
 source-repository head
     type: git
     location: git://github.com/koalaman/shellcheck.git
@@ -38,7 +44,7 @@ source-repository head
 library
     build-depends:
       base >= 4 && < 5,
-      containers,
+      containers >= 0.5,
       directory,
       json,
       mtl >= 2.2.1,
@@ -73,9 +79,9 @@ executable shellcheck
       base >= 4 && < 5,
       containers,
       directory,
-      json,
+      json >= 0.3.6,
       mtl >= 2.2.1,
-      parsec,
+      parsec >= 3.0,
       regex-tdfa,
       QuickCheck >= 2.7.4
     main-is: shellcheck.hs


### PR DESCRIPTION
custom-setup:

- http://cabal.readthedocs.io/en/latest/developing-packages.html#custom-setup-scripts
- https://www.well-typed.com/blog/2015/07/cabal-setup-deps/

Bounds:
- containers-0.5 is required if Data.Map.Strict
- parsec-3.0 for Text.Parsec
- json-0.3.6 for makeObj

---

I (as [Hackage Trustee](https://github.com/haskell-infra/hackage-trustees)) [revised](https://github.com/haskell-infra/hackage-trustees/blob/master/revisions-information.md) the bounds http://hackage.haskell.org/package/ShellCheck-0.4.7/revisions/ So no release is needed because of these changes.