### PR TITLE
Consider type a valid command in sh

### DIFF
--- a/src/ShellCheck/Checks/ShellSupport.hs
+++ b/src/ShellCheck/Checks/ShellSupport.hs
@@ -277,7 +277,7 @@ checkBashisms = ForShell [Sh, Dash] $ \t -> do
             "let", "caller", "builtin", "complete", "compgen", "declare", "dirs", "disown",
             "enable", "mapfile", "readarray", "pushd", "popd", "shopt", "suspend",
             "typeset"
-            ] ++ if not isDash then ["local", "type"] else []
+            ] ++ if not isDash then ["local"] else []
         allowedFlags = Map.fromList [
             ("exec", []),
             ("export", ["-p"]),


### PR DESCRIPTION
[type](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/type.html) *is* defined by POSIX, and even the bourne shell has the `type` command.