### PR TITLE
Improve snap packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,10 @@ cabal-dev
 cabal.sandbox.config
 cabal.config
 .stack-work
+
+### Snap ###
+/snap/.snapcraft/
+/stage/
+/parts/
+/prime/
+*.snap

--- a/README.md
+++ b/README.md
@@ -139,6 +139,10 @@ On Solus:
 
     eopkg install shellcheck
 
+From Snap Store:
+
+    snap install --channel=edge shellcheck
+
 From Docker Hub:
 
 ```sh

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -15,6 +15,13 @@ description: |
   - To point out subtle caveats, corner cases and pitfalls that may cause an
     advanced user's otherwise working script to fail under future
     circumstances.
+
+  By default ShellCheck can only check non-hidden files under /home, to make 
+  ShellCheck be able to check files under /media and /run/media you must
+  connect it to the `removable-media` interface manually:
+
+      # snap connect shellcheck:removable-media
+  
 version: git
 grade: devel
 confinement: strict

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,7 +22,7 @@ confinement: strict
 apps:
   shellcheck:
     command: usr/bin/shellcheck
-    plugs: [home]
+    plugs: [home, removable-media]
 
 parts:
   shellcheck:


### PR DESCRIPTION
This pull request adds some improvements regarding to the snap packaging:

commit 366dc5d3f8b56166df8aa7406794019280e5a071
Author: 林博仁(Buo-Ren Lin) <Buo.Ren.Lin@gmail.com>
Date:   Thu Mar 29 20:24:31 2018 +0800

    Add snap install instructions to README
    
    Currently shellcheck is only provided by the edge channel, should remove the --channel argument after it is in candidate/stable.
    
    Signed-off-by: 林博仁(Buo-Ren Lin) <Buo.Ren.Lin@gmail.com>

commit 1ed743e4101b12c54ed05c53d5b58a6336cc1c24
Author: 林博仁(Buo-Ren Lin) <Buo.Ren.Lin@gmail.com>
Date:   Thu Mar 29 20:05:52 2018 +0800

    Add snapcraft generated files to the Git tracking ignore rules
    
    This patches uses the following gitignore syntax so that only entries in the root folder is ignored, it is suggested to apply it to existing rules as well.
    
    ```
    A leading slash matches the beginning of the pathname. For
    example, "/*.c" matches "cat-file.c" but not
    "mozilla-sha1/sha1.c".
    ```
    
    Refer-to: gitignore(5) manpage
    Signed-off-by: 林博仁(Buo-Ren Lin) <Buo.Ren.Lin@gmail.com>

commit 9a2aad16adff0cc9cf6d7ce8d6a7bd7cd09810bc
Author: 林博仁(Buo-Ren Lin) <Buo.Ren.Lin@gmail.com>
Date:   Thu Mar 29 17:59:48 2018 +0800

    Add removable-media plug so that scripts in removable media can be checked
    
    Otherwise it will be blocked by Apparmor with the following message:
    
    ```
    $ shellcheck script
    audit: type=1400 audit(TIMESTAMP): apparmor="DENIED" operation="open" profile="snap.shellcheck.shellcheck" name=2F6D656469612F4C696E2D42756F2D52656E2F57696E646F7773205553422F717569636B72756E pid=10175 comm="shellcheck" requested_mask="r" denied_mask="r" fsuid=FSUID ouid=OUID
    script: script: openBinaryFile: permission denied (Permission denied)
    ```
    
    NOTE:
    
    * This plug is not Auto-connect plug, it has to be manually connected by user with `snap connect shellcheck:removable-media :removable-media`
    * Currently files under /mnt is not checkable as snapd doesn't provide an interface for it for now.
    
    Refer-to: Interfaces reference - Snaps are universal Linux packages <https://docs.snapcraft.io/reference/interfaces>
    Signed-off-by: 林博仁(Buo-Ren Lin) <Buo.Ren.Lin@gmail.com>
