### PR TITLE
Bump to ghc 8.4.1

### DIFF
--- a/ShellCheck.cabal
+++ b/ShellCheck.cabal
@@ -43,6 +43,9 @@ source-repository head
 
 library
     hs-source-dirs: src
+    if impl(ghc < 8.0)
+      build-depends:
+        semigroups
     build-depends:
       -- GHC 7.6.3 (base 4.6.0.1) is buggy (#1131, #1119) in optimized mode.
       -- Just disable that version entirely to fail fast.
@@ -78,6 +81,9 @@ library
       Paths_ShellCheck
 
 executable shellcheck
+    if impl(ghc < 8.0)
+      build-depends:
+        semigroups
     build-depends:
       base >= 4 && < 5,
       ShellCheck, 

--- a/src/ShellCheck/AnalyzerLib.hs
+++ b/src/ShellCheck/AnalyzerLib.hs
@@ -466,7 +466,7 @@ getModifiedVariables t =
                     _          -> Nothing
 
             guard . not . null $ str
-            return (t, token, str, DataString $ SourceChecked)
+            return (t, token, str, DataString SourceChecked)
 
         T_DollarBraced _ l -> maybeToList $ do
             let string = bracedString t
@@ -691,9 +691,8 @@ isCommand token str = isCommandMatch token (\cmd -> cmd  == str || ('/' : str) `
 -- Compare a command to a literal. Like above, but checks full path.
 isUnqualifiedCommand token str = isCommandMatch token (== str)
 
-isCommandMatch token matcher = fromMaybe False $ do
-    cmd <- getCommandName token
-    return $ matcher cmd
+isCommandMatch token matcher = fromMaybe False $
+    fmap matcher (getCommandName token)
 
 -- Does this regex look like it was intended as a glob?
 -- True:  *foo*


### PR DESCRIPTION
Currently, shellcheck fails to build with ghc-8.4.1. This fixes that, while maintaining compatibility with ghc-7.8.4. 