### PR TITLE
Add T_SourceCommand to wrap source commands and sourced code

### DIFF
--- a/src/ShellCheck/AST.hs
+++ b/src/ShellCheck/AST.hs
@@ -134,7 +134,8 @@ data Token =
     | T_Pipe Id String
     | T_CoProc Id (Maybe String) Token
     | T_CoProcBody Id Token
-    | T_Include Id Token Token -- . & source: SimpleCommand T_Script
+    | T_Include Id Token
+    | T_SourceCommand Id Token Token
     deriving (Show)
 
 data Annotation =
@@ -270,7 +271,8 @@ analyze f g i =
     delve (T_Annotation id anns t) = d1 t $ T_Annotation id anns
     delve (T_CoProc id var body) = d1 body $ T_CoProc id var
     delve (T_CoProcBody id t) = d1 t $ T_CoProcBody id
-    delve (T_Include id includer script) = d2 includer script $ T_Include id
+    delve (T_Include id script) = d1 script $ T_Include id
+    delve (T_SourceCommand id includer t_include) = d2 includer t_include $ T_SourceCommand id
     delve t = return t
 
 getId :: Token -> Id
@@ -370,7 +372,8 @@ getId t = case t of
         T_Pipe id _ -> id
         T_CoProc id _ _ -> id
         T_CoProcBody id _ -> id
-        T_Include id _ _ -> id
+        T_Include id _ -> id
+        T_SourceCommand id _ _ -> id
         T_UnparsedIndex id _ _ -> id
         TC_Empty id _ -> id
         TA_Variable id _ _ -> id

--- a/src/ShellCheck/Checks/ShellSupport.hs
+++ b/src/ShellCheck/Checks/ShellSupport.hs
@@ -283,7 +283,10 @@ checkBashisms = ForShell [Sh, Dash] $ \t -> do
             ("read", if isDash then ["r", "p"] else ["r"]),
             ("ulimit", ["f"])
             ]
-
+    bashism t@(T_SourceCommand id src _) =
+        let name = fromMaybe "" $ getCommandName src
+        in do
+            when (name == "source") $ warnMsg id "'source' in place of '.' is"
     bashism _ = return ()
 
     varChars="_0-9a-zA-Z"

--- a/src/ShellCheck/Parser.hs
+++ b/src/ShellCheck/Parser.hs
@@ -1922,7 +1922,7 @@ readSource pos t@(T_Redirecting _ _ (T_SimpleCommand _ _ (cmd:file:_))) = do
 
                         let included = do
                             src <- subRead filename script
-                            return $ T_Include id t src
+                            return $ T_SourceCommand id t (T_Include id src)
 
                         let failed = do
                             parseNoteAt pos WarningC 1094


### PR DESCRIPTION
Fixes #1181 
Id is not used in T_Include, but I figured i'll leave it there so functions like getId don't have to change.