### PR TITLE
replace CS2006 message 

### DIFF
--- a/src/ShellCheck/Analytics.hs
+++ b/src/ShellCheck/Analytics.hs
@@ -1324,7 +1324,7 @@ prop_checkBackticks1 = verify checkBackticks "echo `foo`"
 prop_checkBackticks2 = verifyNot checkBackticks "echo $(foo)"
 prop_checkBackticks3 = verifyNot checkBackticks "echo `#inlined comment` foo"
 checkBackticks _ (T_Backticked id list) | not (null list) =
-    style id 2006 "Use $(..) instead of legacy `..`."
+    style id 2006 "Use $(STATEMENT) instead of legacy `STATEMENT`."
 checkBackticks _ _ = return ()
 
 prop_checkIndirectExpansion1 = verify checkIndirectExpansion "${foo$n}"


### PR DESCRIPTION
my colleague @andk discovered the issue. I just provide his proposal.

- test script `t.sh`
```bash
#!/usr/bin/env bash
DATE=`date`
echo "$DATE"

```

- running test without PR
```bash
$ stack exec -- shellcheck t.sh

In t.sh line 2:
DATE=`date`
     ^----^ SC2006: Use $(..) instead of legacy `..`.
```

PR uses the headline of https://github.com/koalaman/shellcheck/wiki/Sc2006

- running test with PR
```bash
$ stack exec -- shellcheck t.sh

In t.sh line 2:
DATE=`date`
     ^----^ SC2006: Use $(STATEMENT) instead of legacy `STATEMENT`.

```