### PR TITLE
Make data in Interface more opaque

### DIFF
--- a/shellcheck.hs
+++ b/shellcheck.hs
@@ -73,7 +73,7 @@ data Options = Options {
 defaultOptions = Options {
     checkSpec = emptyCheckSpec,
     externalSources = False,
-    formatterOptions = FormatterOptions {
+    formatterOptions = newFormatterOptions {
         foColorOption = ColorAuto
     }
 }

--- a/src/ShellCheck/Analyzer.hs
+++ b/src/ShellCheck/Analyzer.hs
@@ -30,7 +30,7 @@ import qualified ShellCheck.Checks.ShellSupport
 
 -- TODO: Clean up the cruft this is layered on
 analyzeScript :: AnalysisSpec -> AnalysisResult
-analyzeScript spec = AnalysisResult {
+analyzeScript spec = newAnalysisResult {
     arComments =
         filterByAnnotation spec params . nub $
             runAnalytics spec

--- a/src/ShellCheck/Formatter/JSON.hs
+++ b/src/ShellCheck/Formatter/JSON.hs
@@ -40,7 +40,10 @@ format = do
     }
 
 instance ToJSON (PositionedComment) where
-  toJSON comment@(PositionedComment start end (Comment level code string)) =
+  toJSON comment =
+    let start = pcStartPos comment
+        end = pcEndPos comment
+        c = pcComment comment in
     object [
       "file" .= posFile start,
       "line" .= posLine start,
@@ -48,11 +51,14 @@ instance ToJSON (PositionedComment) where
       "column" .= posColumn start,
       "endColumn" .= posColumn end,
       "level" .= severityText comment,
-      "code" .= code,
-      "message" .= string
+      "code" .= cCode c,
+      "message" .= cMessage c
     ]
 
-  toEncoding comment@(PositionedComment start end (Comment level code string)) =
+  toEncoding comment =
+    let start = pcStartPos comment
+        end = pcEndPos comment
+        c = pcComment comment in
     pairs (
          "file" .= posFile start
       <> "line" .= posLine start
@@ -60,8 +66,8 @@ instance ToJSON (PositionedComment) where
       <> "column" .= posColumn start
       <> "endColumn" .= posColumn end
       <> "level" .= severityText comment
-      <> "code" .= code
-      <> "message" .= string
+      <> "code" .= cCode c
+      <> "message" .= cMessage c
     )
 
 outputError file msg = hPutStrLn stderr $ file ++ ": " ++ msg

--- a/src/ShellCheck/Interface.hs
+++ b/src/ShellCheck/Interface.hs
@@ -17,7 +17,39 @@
     You should have received a copy of the GNU General Public License
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 -}
-module ShellCheck.Interface where
+module ShellCheck.Interface
+    (
+    SystemInterface(..)
+    , CheckSpec(csFilename, csScript, csCheckSourced, csExcludedWarnings, csShellTypeOverride)
+    , CheckResult(crFilename, crComments)
+    , ParseSpec(psFilename, psScript, psCheckSourced, psShellTypeOverride)
+    , ParseResult(prComments, prTokenPositions, prRoot)
+    , AnalysisSpec(asScript, asShellType, asExecutionMode, asCheckSourced)
+    , AnalysisResult(arComments)
+    , FormatterOptions(foColorOption)
+    , Shell(Ksh, Sh, Bash, Dash)
+    , ExecutionMode(Executed, Sourced)
+    , ErrorMessage
+    , Code
+    , Severity(ErrorC, WarningC, InfoC, StyleC)
+    , Position(posFile, posLine, posColumn)
+    , Comment(cSeverity, cCode, cMessage)
+    , PositionedComment(pcStartPos , pcEndPos , pcComment)
+    , ColorOption(ColorAuto, ColorAlways, ColorNever)
+    , TokenComment(tcId, tcComment)
+    , emptyCheckResult
+    , newParseResult
+    , newAnalysisSpec
+    , newAnalysisResult
+    , newFormatterOptions
+    , newPosition
+    , newTokenComment
+    , mockedSystemInterface
+    , newParseSpec
+    , emptyCheckSpec
+    , newPositionedComment
+    , newComment
+    ) where
 
 import ShellCheck.AST
 import Control.Monad.Identity
@@ -42,6 +74,12 @@ data CheckResult = CheckResult {
     crFilename :: String,
     crComments :: [PositionedComment]
 } deriving (Show, Eq)
+
+emptyCheckResult :: CheckResult
+emptyCheckResult = CheckResult {
+    crFilename = "",
+    crComments = []
+}
 
 emptyCheckSpec :: CheckSpec
 emptyCheckSpec = CheckSpec {
@@ -74,6 +112,13 @@ data ParseResult = ParseResult {
     prRoot :: Maybe Token
 } deriving (Show, Eq)
 
+newParseResult :: ParseResult
+newParseResult = ParseResult {
+    prComments = [],
+    prTokenPositions = Map.empty,
+    prRoot = Nothing
+}
+
 -- Analyzer input and output
 data AnalysisSpec = AnalysisSpec {
     asScript :: Token,
@@ -82,14 +127,28 @@ data AnalysisSpec = AnalysisSpec {
     asCheckSourced :: Bool
 }
 
+newAnalysisSpec token = AnalysisSpec {
+    asScript = token,
+    asShellType = Nothing,
+    asExecutionMode = Executed,
+    asCheckSourced = False
+}
+
 newtype AnalysisResult = AnalysisResult {
     arComments :: [TokenComment]
 }
 
+newAnalysisResult = AnalysisResult {
+    arComments = []
+}
 
 -- Formatter options
 newtype FormatterOptions = FormatterOptions {
     foColorOption :: ColorOption
+}
+
+newFormatterOptions = FormatterOptions {
+    foColorOption = ColorAuto
 }
 
 
@@ -107,9 +166,48 @@ data Position = Position {
     posColumn :: Integer  -- 1 based source column, where tabs are 8
 } deriving (Show, Eq)
 
-data Comment = Comment Severity Code String deriving (Show, Eq)
-data PositionedComment = PositionedComment Position Position Comment deriving (Show, Eq)
-data TokenComment = TokenComment Id Comment deriving (Show, Eq)
+newPosition :: Position
+newPosition = Position {
+    posFile   = "",
+    posLine   = 1,
+    posColumn = 1
+}
+
+data Comment = Comment {
+    cSeverity :: Severity,
+    cCode     :: Code,
+    cMessage  :: String
+} deriving (Show, Eq)
+
+newComment :: Comment
+newComment = Comment {
+    cSeverity = StyleC,
+    cCode     = 0,
+    cMessage  = ""
+}
+
+data PositionedComment = PositionedComment {
+    pcStartPos :: Position,
+    pcEndPos   :: Position,
+    pcComment  :: Comment
+} deriving (Show, Eq)
+
+newPositionedComment :: PositionedComment
+newPositionedComment = PositionedComment {
+    pcStartPos = newPosition,
+    pcEndPos   = newPosition,
+    pcComment  = newComment
+}
+
+data TokenComment = TokenComment {
+    tcId :: Id,
+    tcComment :: Comment
+} deriving (Show, Eq)
+
+newTokenComment = TokenComment {
+    tcId = Id 0,
+    tcComment = newComment
+}
 
 data ColorOption =
     ColorAuto

--- a/src/ShellCheck/Parser.hs
+++ b/src/ShellCheck/Parser.hs
@@ -3050,11 +3050,11 @@ debugParseScript string =
     result {
         -- Remove the noisiest parts
         prTokenPositions = Map.fromList [
-            (Id 0, (Position {
+            (Id 0, (newPosition {
                 posFile = "removed for clarity",
                 posLine = -1,
                 posColumn = -1
-            }, Position {
+            }, newPosition {
                 posFile = "removed for clarity",
                 posLine = -1,
                 posColumn = -1
@@ -3143,14 +3143,14 @@ parseShell env name contents = do
     (result, state) <- runParser env (parseWithNotes readScript) name contents
     case result of
         Right (script, userstate) ->
-            return ParseResult {
+            return newParseResult {
                 prComments = map toPositionedComment $ nub $ parseNotes userstate ++ parseProblems state,
                 prTokenPositions = Map.map startEndPosToPos (positionMap userstate),
                 prRoot = Just $
                     reattachHereDocs script (hereDocMap userstate)
             }
         Left err ->
-            return ParseResult {
+            return newParseResult {
                 prComments =
                     map toPositionedComment $
                         notesForContext (contextStack state)
@@ -3217,10 +3217,18 @@ reattachHereDocs root map =
 
 toPositionedComment :: ParseNote -> PositionedComment
 toPositionedComment (ParseNote start end severity code message) =
-    PositionedComment (posToPos start) (posToPos end) $ Comment severity code message
+    newPositionedComment {
+        pcStartPos = (posToPos start)
+      , pcEndPos = (posToPos end)
+      , pcComment = newComment {
+          cSeverity = severity
+        , cCode = code
+        , cMessage = message
+      }
+    }
 
 posToPos :: SourcePos -> Position
-posToPos sp = Position {
+posToPos sp = newPosition {
     posFile = sourceName sp,
     posLine = fromIntegral $ sourceLine sp,
     posColumn = fromIntegral $ sourceColumn sp


### PR DESCRIPTION
Create a new data type Fix that represents suggested fix for a warning. Right now there is only one variant, which is a Surround String, representing a fix that surrounds the warning with a string.
This is created using `makeCommentWithFix`

Also worked on making the data types in interface more opaque, exposing all the record accessor functions. Not sure if this is alright, please take a look?