### PR TITLE
Add command-line option -S/--severity

### DIFF
--- a/shellcheck.1.md
+++ b/shellcheck.1.md
@@ -56,6 +56,11 @@ not warn at all, as `ksh` supports decimals in arithmetic contexts.
     standard output. Subsequent **-f** options are ignored, see **FORMATS**
     below for more information.
 
+**-S**\ *SEVERITY*,\ **--severity=***severity*
+
+:   Specify maximum severity of errors to consider. Valid values are *error*,
+    *warning*, *info* and *style*.    The default is *style*.
+
 **-s**\ *shell*,\ **--shell=***shell*
 
 :   Specify Bourne shell dialect. Valid values are *sh*, *bash*, *dash* and *ksh*.

--- a/shellcheck.1.md
+++ b/shellcheck.1.md
@@ -58,7 +58,7 @@ not warn at all, as `ksh` supports decimals in arithmetic contexts.
 
 **-S**\ *SEVERITY*,\ **--severity=***severity*
 
-:   Specify maximum severity of errors to consider. Valid values are *error*,
+:   Specify minimum severity of errors to consider. Valid values are *error*,
     *warning*, *info* and *style*.    The default is *style*.
 
 **-s**\ *shell*,\ **--shell=***shell*

--- a/shellcheck.hs
+++ b/shellcheck.hs
@@ -67,7 +67,8 @@ instance Monoid Status where
 data Options = Options {
     checkSpec        :: CheckSpec,
     externalSources  :: Bool,
-    formatterOptions :: FormatterOptions
+    formatterOptions :: FormatterOptions,
+    maxSeverity      :: Severity
 }
 
 defaultOptions = Options {
@@ -75,7 +76,8 @@ defaultOptions = Options {
     externalSources = False,
     formatterOptions = FormatterOptions {
         foColorOption = ColorAuto
-    }
+    },
+    maxSeverity = StyleC
 }
 
 usageHeader = "Usage: shellcheck [OPTIONS...] FILES..."
@@ -93,6 +95,9 @@ options = [
     Option "s" ["shell"]
         (ReqArg (Flag "shell") "SHELLNAME")
         "Specify dialect (sh, bash, dash, ksh)",
+    Option "S" ["severity"]
+        (ReqArg (Flag "severity") "SEVERITY")
+        "Maximum severity of errors to consider (error, warning, info, style)",
     Option "V" ["version"]
         (NoArg $ Flag "version" "true") "Print version information",
     Option "x" ["external-sources"]
@@ -223,6 +228,14 @@ parseColorOption colorOption =
         "never"  -> ColorNever
         _        -> error $ "Bad value for --color `" ++ colorOption ++ "'"
 
+parseSeverityOption severityOption =
+    case severityOption of
+        "error"   -> ErrorC
+        "warning" -> WarningC
+        "info"    -> InfoC
+        "style"   -> StyleC
+        _         -> error $ "Bad value for --severity `" ++ severityOption ++ "'"
+
 parseOption flag options =
     case flag of
         Flag "shell" str ->
@@ -263,6 +276,13 @@ parseOption flag options =
             return options {
                 checkSpec = (checkSpec options) {
                     csCheckSourced = True
+                }
+            }
+
+        Flag "severity" severity ->
+            return options {
+                checkSpec = (checkSpec options) {
+                    csMaxSeverity = parseSeverityOption severity
                 }
             }
 

--- a/shellcheck.hs
+++ b/shellcheck.hs
@@ -68,7 +68,7 @@ data Options = Options {
     checkSpec        :: CheckSpec,
     externalSources  :: Bool,
     formatterOptions :: FormatterOptions,
-    maxSeverity      :: Severity
+    minSeverity      :: Severity
 }
 
 defaultOptions = Options {
@@ -77,7 +77,7 @@ defaultOptions = Options {
     formatterOptions = FormatterOptions {
         foColorOption = ColorAuto
     },
-    maxSeverity = StyleC
+    minSeverity = StyleC
 }
 
 usageHeader = "Usage: shellcheck [OPTIONS...] FILES..."
@@ -97,7 +97,7 @@ options = [
         "Specify dialect (sh, bash, dash, ksh)",
     Option "S" ["severity"]
         (ReqArg (Flag "severity") "SEVERITY")
-        "Maximum severity of errors to consider (error, warning, info, style)",
+        "Minimum severity of errors to consider (error, warning, info, style)",
     Option "V" ["version"]
         (NoArg $ Flag "version" "true") "Print version information",
     Option "x" ["external-sources"]
@@ -282,7 +282,7 @@ parseOption flag options =
         Flag "severity" severity ->
             return options {
                 checkSpec = (checkSpec options) {
-                    csMaxSeverity = parseSeverityOption severity
+                    csMinSeverity = parseSeverityOption severity
                 }
             }
 

--- a/src/ShellCheck/Checker.hs
+++ b/src/ShellCheck/Checker.hs
@@ -67,7 +67,8 @@ checkScript sys spec = do
         return . nub . sortMessages . filter shouldInclude $
             (parseMessages ++ map translator analysisMessages)
 
-    shouldInclude (PositionedComment _ _ (Comment _ code _)) =
+    shouldInclude (PositionedComment _ _ (Comment severity code _)) =
+        severity <= csMaxSeverity spec &&
         code `notElem` csExcludedWarnings spec
 
     sortMessages = sortBy (comparing order)

--- a/src/ShellCheck/Checker.hs
+++ b/src/ShellCheck/Checker.hs
@@ -68,7 +68,7 @@ checkScript sys spec = do
             (parseMessages ++ map translator analysisMessages)
 
     shouldInclude (PositionedComment _ _ (Comment severity code _)) =
-        severity <= csMaxSeverity spec &&
+        severity <= csMinSeverity spec &&
         code `notElem` csExcludedWarnings spec
 
     sortMessages = sortBy (comparing order)

--- a/src/ShellCheck/Interface.hs
+++ b/src/ShellCheck/Interface.hs
@@ -36,7 +36,7 @@ data CheckSpec = CheckSpec {
     csCheckSourced :: Bool,
     csExcludedWarnings :: [Integer],
     csShellTypeOverride :: Maybe Shell,
-    csMaxSeverity :: Severity
+    csMinSeverity :: Severity
 } deriving (Show, Eq)
 
 data CheckResult = CheckResult {
@@ -51,7 +51,7 @@ emptyCheckSpec = CheckSpec {
     csCheckSourced = False,
     csExcludedWarnings = [],
     csShellTypeOverride = Nothing,
-    csMaxSeverity = StyleC
+    csMinSeverity = StyleC
 }
 
 newParseSpec :: ParseSpec

--- a/src/ShellCheck/Interface.hs
+++ b/src/ShellCheck/Interface.hs
@@ -35,7 +35,8 @@ data CheckSpec = CheckSpec {
     csScript :: String,
     csCheckSourced :: Bool,
     csExcludedWarnings :: [Integer],
-    csShellTypeOverride :: Maybe Shell
+    csShellTypeOverride :: Maybe Shell,
+    csMaxSeverity :: Severity
 } deriving (Show, Eq)
 
 data CheckResult = CheckResult {
@@ -49,7 +50,8 @@ emptyCheckSpec = CheckSpec {
     csScript = "",
     csCheckSourced = False,
     csExcludedWarnings = [],
-    csShellTypeOverride = Nothing
+    csShellTypeOverride = Nothing,
+    csMaxSeverity = StyleC
 }
 
 newParseSpec :: ParseSpec


### PR DESCRIPTION
Specifies the maximum severity of errors to handle.  For example,
specifying "-S warning" means that errors of severity "info" and
"style" are ignored.

Signed-off-by: Martin Schwenke <martin@meltin.net>