### PR TITLE
Add link to flymake-shellcheck under Emacs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ You can see ShellCheck suggestions directly in a variety of editors.
 
 ![Screenshot of Vim showing inlined shellcheck feedback](doc/vim-syntastic.png).
 
-* Emacs, through [Flycheck](https://github.com/flycheck/flycheck):
+* Emacs, through [Flycheck](https://github.com/flycheck/flycheck) or [Flymake](https://github.com/federicotdn/flymake-shellcheck):
 
 ![Screenshot of emacs showing inlined shellcheck feedback](doc/emacs-flycheck.png).
 


### PR DESCRIPTION
I've recently created the flymake-shellcheck package for Emacs, which allows using ShellCheck with the built-in Flymake package.

This commit adds a link (https://github.com/federicotdn/flymake-shellcheck) to the `flymake-shellcheck` GitHub page, which contains installation instructions.