### PR TITLE
Remove 'du' from list of non-reading commands

### DIFF
--- a/src/ShellCheck/Data.hs
+++ b/src/ShellCheck/Data.hs
@@ -79,7 +79,7 @@ commonCommands = [
 
 nonReadingCommands = [
     "alias", "basename", "bg", "cal", "cd", "chgrp", "chmod", "chown",
-    "cp", "du", "echo", "export", "false", "fg", "fuser", "getconf",
+    "cp", "echo", "export", "false", "fg", "fuser", "getconf",
     "getopt", "getopts", "ipcrm", "ipcs", "jobs", "kill", "ln", "ls",
     "locale", "mv", "printf", "ps", "pwd", "renice", "rm", "rmdir",
     "set", "sleep", "touch", "trap", "true", "ulimit", "unalias", "uname"


### PR DESCRIPTION
Remove 'du' from list of non-reading commands due to it being able to read from stdin:

>  --files0-from=F
> summarize disk usage of the NUL-terminated file names specified in file F; if F is -, then read names from standard input