### PR TITLE
Prototype fix

### DIFF
--- a/src/ShellCheck/Analytics.hs
+++ b/src/ShellCheck/Analytics.hs
@@ -249,7 +249,11 @@ replace_start id params n r =
             posColumn = posColumn start + n
         }
     in
-    [R start new_end r]
+    newReplacement {
+        repStartPos = start,
+        repEndPos = new_end,
+        repString = r
+    }
 replace_end id params n r =
     -- because of the way we count columns 1-based
     -- we have to offset end columns by 1
@@ -262,9 +266,13 @@ replace_end id params n r =
             posColumn = posColumn end + 1
         }
     in
-    [R new_start new_end r]
+    newReplacement {
+        repStartPos = new_start,
+        repEndPos = new_end,
+        repString = r
+    }
 surround_with id params s =
-    (replace_start id params 0 s) ++ (replace_end id params 0 s)
+    [replace_start id params 0 s, replace_end id params 0 s]
 
 prop_checkEchoWc3 = verify checkEchoWc "n=$(echo $foo | wc -c)"
 checkEchoWc _ (T_Pipeline id _ [a, b]) =
@@ -1362,7 +1370,7 @@ prop_checkBackticks3 = verifyNot checkBackticks "echo `#inlined comment` foo"
 checkBackticks params (T_Backticked id list) | not (null list) =
     addComment $
         makeCommentWithFix StyleC id 2006  "Use $(...) notation instead of legacy backticked `...`."
-            ((replace_start id params 1 "$(") ++ (replace_end id params 1 ")"))
+            [(replace_start id params 1 "$("), (replace_end id params 1 ")")]
     -- style id 2006 "Use $(...) notation instead of legacy backticked `...`."
 checkBackticks _ _ = return ()
 
@@ -2569,7 +2577,7 @@ checkUncheckedCdPushdPopd params root =
             && not (isCondition $ getPath (parentMap params) t)) $
                 -- warn (getId t) 2164 "Use 'cd ... || exit' or 'cd ... || return' in case cd fails."
                 warnWithFix (getId t) 2164 "Use 'cd ... || exit' or 'cd ... || return' in case cd fails."
-                    (replace_end (getId t) params 0 " || exit")
+                    [replace_end (getId t) params 0 " || exit"]
     checkElement _ = return ()
     name t = fromMaybe "" $ getCommandName t
     isSafeDir t = case oversimplify t of

--- a/src/ShellCheck/AnalyzerLib.hs
+++ b/src/ShellCheck/AnalyzerLib.hs
@@ -81,7 +81,8 @@ data Parameters = Parameters {
     parentMap          :: Map.Map Id Token, -- A map from Id to parent Token
     shellType          :: Shell,            -- The shell type, such as Bash or Ksh
     shellTypeSpecified :: Bool,    -- True if shell type was forced via flags
-    rootNode           :: Token              -- The root node of the AST
+    rootNode           :: Token,              -- The root node of the AST
+    tokenPositions     :: Map.Map Id (Position, Position) -- map from token id to start and end position
     }
 
 -- TODO: Cache results of common AST ops here
@@ -177,7 +178,8 @@ makeParameters spec =
 
         shellTypeSpecified = isJust $ asShellType spec,
         parentMap = getParentTree root,
-        variableFlow = getVariableFlow params root
+        variableFlow = getVariableFlow params root,
+        tokenPositions = asTokenPositions spec
     } in params
   where root = asScript spec
 

--- a/src/ShellCheck/AnalyzerLib.hs
+++ b/src/ShellCheck/AnalyzerLib.hs
@@ -150,6 +150,19 @@ err   id code str = addComment $ makeComment ErrorC id code str
 info  id code str = addComment $ makeComment InfoC id code str
 style id code str = addComment $ makeComment StyleC id code str
 
+warnWithFix id code str fix = addComment $
+    let comment = makeComment WarningC id code str in
+    comment {
+        tcFix = Just fix
+    }
+
+makeCommentWithFix :: Severity -> Id -> Code -> String -> Fix -> TokenComment
+makeCommentWithFix severity id code str fix =
+    let comment = makeComment severity id code str in
+    comment {
+        tcFix = Just fix
+    }
+
 makeParameters spec =
     let params = Parameters {
         rootNode = root,

--- a/src/ShellCheck/Checker.hs
+++ b/src/ShellCheck/Checker.hs
@@ -64,11 +64,20 @@ checkScript sys spec = do
             psShellTypeOverride = csShellTypeOverride spec
         }
         let parseMessages = prComments result
+        let tokenPositions = prTokenPositions result
+        let analysisSpec root =
+                as {
+                    asScript = root,
+                    asShellType = csShellTypeOverride spec,
+                    asCheckSourced = csCheckSourced spec,
+                    asExecutionMode = Executed,
+                    asTokenPositions = tokenPositions
+                } where as = newAnalysisSpec root
         let analysisMessages =
                 fromMaybe [] $
                     (arComments . analyzeScript . analysisSpec)
                         <$> prRoot result
-        let translator = tokenToPosition (prTokenPositions result)
+        let translator = tokenToPosition tokenPositions
         return . nub . sortMessages . filter shouldInclude $
             (parseMessages ++ map translator analysisMessages)
 
@@ -91,13 +100,6 @@ checkScript sys spec = do
          cMessage comment)
     getPosition = pcStartPos
 
-    analysisSpec root =
-        as {
-            asScript = root,
-            asShellType = csShellTypeOverride spec,
-            asCheckSourced = csCheckSourced spec,
-            asExecutionMode = Executed
-         } where as = newAnalysisSpec root
 
 getErrors sys spec =
     sort . map getCode . crComments $

--- a/src/ShellCheck/Checker.hs
+++ b/src/ShellCheck/Checker.hs
@@ -42,7 +42,8 @@ tokenToPosition startMap t = fromMaybe fail $ do
     return $ newPositionedComment {
         pcStartPos = fst span,
         pcEndPos = snd span,
-        pcComment = tcComment t
+        pcComment = tcComment t,
+        pcFix = tcFix t
     }
   where
     fail = error "Internal shellcheck error: id doesn't exist. Please report!"

--- a/src/ShellCheck/Formatter/JSON.hs
+++ b/src/ShellCheck/Formatter/JSON.hs
@@ -39,6 +39,19 @@ format = do
         footer = finish ref
     }
 
+instance ToJSON Replacement where
+    toJSON replacement =
+        let start = repStartPos replacement
+            end = repEndPos replacement
+            str = repString replacement in
+        object [
+          "line" .= posLine start,
+          "endLine" .= posLine end,
+          "column" .= posColumn start,
+          "endColumn" .= posColumn end,
+          "replaceWith" .= str
+        ]
+
 instance ToJSON (PositionedComment) where
   toJSON comment =
     let start = pcStartPos comment
@@ -52,7 +65,8 @@ instance ToJSON (PositionedComment) where
       "endColumn" .= posColumn end,
       "level" .= severityText comment,
       "code" .= cCode c,
-      "message" .= cMessage c
+      "message" .= cMessage c,
+      "fix" .= pcFix comment
     ]
 
   toEncoding comment =
@@ -68,6 +82,7 @@ instance ToJSON (PositionedComment) where
       <> "level" .= severityText comment
       <> "code" .= cCode c
       <> "message" .= cMessage c
+      <> "replaceWith" .= pcFix comment
     )
 
 outputError file msg = hPutStrLn stderr $ file ++ ": " ++ msg
@@ -77,4 +92,3 @@ collectResult ref result _ =
 finish ref = do
     list <- readIORef ref
     BL.putStrLn $ encode list
-

--- a/src/ShellCheck/Formatter/TTY.hs
+++ b/src/ShellCheck/Formatter/TTY.hs
@@ -142,11 +142,12 @@ fixedString comment line =
         apply_replacement rs line 0
         where
             apply_replacement [] s _ = s
-            apply_replacement ((R startp endp r):xs) s offset =
-                let start = posColumn startp
-                    end = posColumn endp
-                    z = do_replace start end s r
-                    len_r = (fromIntegral . length) r in
+            apply_replacement (rep:xs) s offset =
+                let replacementString = repString rep
+                    start = (posColumn . repStartPos) rep
+                    end = (posColumn . repEndPos) rep
+                    z = do_replace start end s replacementString
+                    len_r = (fromIntegral . length) replacementString in
                 apply_replacement xs z (offset + (end - start) + len_r)
 
 -- start and end comes from pos, which is 1 based

--- a/src/ShellCheck/Interface.hs
+++ b/src/ShellCheck/Interface.hs
@@ -50,7 +50,8 @@ module ShellCheck.Interface
     , newPositionedComment
     , newComment
     , Fix
-    , Replacement(R)
+    , Replacement(repStartPos, repEndPos, repString)
+    , newReplacement
     ) where
 
 import ShellCheck.AST
@@ -196,9 +197,17 @@ newComment = Comment {
 }
 
 -- only support single line for now
-data Replacement =
-    R Position Position String
-    deriving (Show, Eq)
+data Replacement = Replacement {
+    repStartPos :: Position,
+    repEndPos :: Position,
+    repString :: String
+} deriving (Show, Eq)
+
+newReplacement = Replacement {
+    repStartPos = newPosition,
+    repEndPos = newPosition,
+    repString = ""
+}
 
 type Fix = [Replacement]
 

--- a/src/ShellCheck/Interface.hs
+++ b/src/ShellCheck/Interface.hs
@@ -24,7 +24,7 @@ module ShellCheck.Interface
     , CheckResult(crFilename, crComments)
     , ParseSpec(psFilename, psScript, psCheckSourced, psShellTypeOverride)
     , ParseResult(prComments, prTokenPositions, prRoot)
-    , AnalysisSpec(asScript, asShellType, asExecutionMode, asCheckSourced)
+    , AnalysisSpec(asScript, asShellType, asExecutionMode, asCheckSourced, asTokenPositions)
     , AnalysisResult(arComments)
     , FormatterOptions(foColorOption, foWikiLinkCount)
     , Shell(Ksh, Sh, Bash, Dash)
@@ -50,10 +50,7 @@ module ShellCheck.Interface
     , newPositionedComment
     , newComment
     , Fix
-    , Replacement(Start, End)
-    , surroundWith
-    , replaceStart
-    , replaceEnd
+    , Replacement(R)
     ) where
 
 import ShellCheck.AST
@@ -132,14 +129,16 @@ data AnalysisSpec = AnalysisSpec {
     asScript :: Token,
     asShellType :: Maybe Shell,
     asExecutionMode :: ExecutionMode,
-    asCheckSourced :: Bool
+    asCheckSourced :: Bool,
+    asTokenPositions :: Map.Map Id (Position, Position)
 }
 
 newAnalysisSpec token = AnalysisSpec {
     asScript = token,
     asShellType = Nothing,
     asExecutionMode = Executed,
-    asCheckSourced = False
+    asCheckSourced = False,
+    asTokenPositions = Map.empty
 }
 
 newtype AnalysisResult = AnalysisResult {
@@ -198,22 +197,10 @@ newComment = Comment {
 
 -- only support single line for now
 data Replacement =
-      Start Integer String
-    | End Integer String
+    R Position Position String
     deriving (Show, Eq)
 
 type Fix = [Replacement]
-
-surroundWith s =
-    (replaceStart 0 s) ++ (replaceEnd 0 s)
-
--- replace first n chars
-replaceStart n r =
-    [ Start n r ]
-
--- replace last n chars
-replaceEnd n r =
-    [ End n r ]
 
 data PositionedComment = PositionedComment {
     pcStartPos :: Position,


### PR DESCRIPTION
Here's a prototype for Fix that is ready for suggestions. The API is pretty simple:
- a Fix is a list of Replacement
- a Replacement has a start Position, end Position (exclusive), and a String to replace the this range with

I added the fix to the json output quite simply, (since it doesn't apply the fix, only specifies what the fix is).

The work on ed-style output, applying fixes, checking for overlaps, can probably come in another PR.

With this test file:
```
#!/bin/bash
DEFS=( -DBADVPN_THREAD_SAFE=0 -DBADVPN_LINUX -DBADVPN_BREACTOR_BADVPN -D_GNU_SOURCE )
echo "${DEFS[1]}"

CC=gcc
CFLAGS="cat a"
"${CC}" -c ${CFLAGS}

cd "$DIR"

CUR_HASH=`$pm2 prettylist | grep "revision" | cut -d: -f2 | tr -d " ,'"``"'"`

echo "$CUR_HASH"
```
The json output is like so:
```
[
   {
      "replaceWith" : [
         {
            "endColumn" : 8,
            "replaceWith" : "\"",
            "line" : 2,
            "endLine" : 2,
            "column" : 8
         },
         {
            "column" : 31,
            "endLine" : 2,
            "line" : 2,
            "replaceWith" : "\"",
            "endColumn" : 31
         }
      ],
      "file" : "test.sh",
      "message" : "The = here is literal. To assign by index, use ( [index]=value ) with no spaces. To keep as literal, quote it.",
      "endColumn" : 30,
      "column" : 8,
      "level" : "warning",
      "endLine" : 2,
      "line" : 2,
      "code" : 2191
   },
   {
      "code" : 2086,
      "line" : 7,
      "endLine" : 7,
      "level" : "info",
      "column" : 12,
      "endColumn" : 21,
      "file" : "test.sh",
      "message" : "Double quote to prevent globbing and word splitting.",
      "replaceWith" : [
         {
            "endColumn" : 12,
            "replaceWith" : "\"",
            "line" : 7,
            "endLine" : 7,
            "column" : 12
         },
         {
            "column" : 22,
            "endLine" : 7,
            "line" : 7,
            "replaceWith" : "\"",
            "endColumn" : 22
         }
      ]
   },
   {
      "endColumn" : 10,
      "message" : "Use 'cd ... || exit' or 'cd ... || return' in case cd fails.",
      "file" : "test.sh",
      "replaceWith" : [
         {
            "endColumn" : 11,
            "line" : 9,
            "replaceWith" : " || exit",
            "endLine" : 9,
            "column" : 11
         }
      ],
      "endLine" : 9,
      "level" : "warning",
      "column" : 1,
      "line" : 9,
      "code" : 2164
   },
   {
      "endLine" : 11,
      "column" : 10,
      "level" : "style",
      "endColumn" : 73,
      "replaceWith" : [
         {
            "replaceWith" : "$(",
            "line" : 11,
            "endColumn" : 11,
            "column" : 10,
            "endLine" : 11
         },
         {
            "column" : 73,
            "endLine" : 11,
            "line" : 11,
            "replaceWith" : ")",
            "endColumn" : 74
         }
      ],
      "message" : "Use $(...) notation instead of legacy backticked `...`.",
      "file" : "test.sh",
      "code" : 2006,
      "line" : 11
   },
   {
      "level" : "warning",
      "column" : 11,
      "endLine" : 11,
      "message" : "pm2 is referenced but not assigned.",
      "file" : "test.sh",
      "replaceWith" : null,
      "endColumn" : 15,
      "code" : 2154,
      "line" : 11
   },
   {
      "endColumn" : 78,
      "replaceWith" : [
         {
            "endLine" : 11,
            "column" : 73,
            "endColumn" : 74,
            "replaceWith" : "$(",
            "line" : 11
         },
         {
            "column" : 78,
            "endLine" : 11,
            "line" : 11,
            "replaceWith" : ")",
            "endColumn" : 79
         }
      ],
      "file" : "test.sh",
      "message" : "Use $(...) notation instead of legacy backticked `...`.",
      "endLine" : 11,
      "column" : 73,
      "level" : "style",
      "line" : 11,
      "code" : 2006
   }
]
```