### PR TITLE
Update Docker build-only image to Ubuntu 18.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build-only image
-FROM ubuntu:17.10 AS build
+FROM ubuntu:18.04 AS build
 USER root
 WORKDIR /opt/shellCheck
 


### PR DESCRIPTION
Ref:
> Ubuntu 17.10 (Artful Aardvark) End of Life reached on July 19 2018
https://fridge.ubuntu.com/2018/07/19/ubuntu-17-10-artful-aardvark-end-of-life-reached-on-july-19-2018/