### PR TITLE
Fix off-by-one in overlap check for fixes

### DIFF
--- a/src/ShellCheck/Fixer.hs
+++ b/src/ShellCheck/Fixer.hs
@@ -10,7 +10,7 @@ class Ranged a where
     end     :: a -> Position
     overlap :: a -> a -> Bool
     overlap x y =
-        (yStart >= xStart && yStart < xEnd) || (yStart < xStart && yEnd > xStart)
+        (yStart >= xStart && yStart <= xEnd) || (yStart < xStart && yEnd > xStart)
         where
             yStart = start y
             yEnd = end y


### PR DESCRIPTION
Previously if we have 2 ranges like:
start: 6, end: 6
start: 6, end: 6
they would not be considered as overlap

Fixes #1431