### PR TITLE
Issue 1318 single comma array delimiter

### DIFF
--- a/src/ShellCheck/Analytics.hs
+++ b/src/ShellCheck/Analytics.hs
@@ -1245,6 +1245,7 @@ prop_checkCommarrays3 = verifyNot checkCommarrays "cow=(1 \"foo,bar\" 3)"
 prop_checkCommarrays4 = verifyNot checkCommarrays "cow=('one,' 'two')"
 prop_checkCommarrays5 = verify checkCommarrays "a=([a]=b, [c]=d)"
 prop_checkCommarrays6 = verify checkCommarrays "a=([a]=b,[c]=d,[e]=f)"
+prop_checkCommarrays7 = verify checkCommarrays "a=(1,2)"
 checkCommarrays _ (T_Array id l) =
     when (any (isCommaSeparated . literal) l) $
         warn id 2054 "Use spaces, not commas, to separate array elements."
@@ -1252,9 +1253,9 @@ checkCommarrays _ (T_Array id l) =
     literal (T_IndexedElement _ _ l) = literal l
     literal (T_NormalWord _ l) = concatMap literal l
     literal (T_Literal _ str) = str
-    literal _ = "str"
+    literal _ = ""
 
-    isCommaSeparated str = "," `isSuffixOf` str || length (filter (== ',') str) > 1
+    isCommaSeparated = elem ','
 checkCommarrays _ _ = return ()
 
 prop_checkOrNeq1 = verify checkOrNeq "if [[ $lol -ne cow || $lol -ne foo ]]; then echo foo; fi"


### PR DESCRIPTION
Issue https://github.com/koalaman/shellcheck/issues/1318

The case in which a single comma, with no spaces, used in an array assignment is now caught for SC2054. A new unit test case was added too.

# Testing
```
I leaf@Sequoia ~/shellcheck (issue_1318_single_comma_array=)> stack test
...
ShellCheck-0.6.0: Test suite test-shellcheck passed
```

## Example script
```
I leaf@Sequoia ~/shellcheck (issue_1318_single_comma_array=)> cat /tmp/example.sh
#!/bin/bash

nowarn=(
        abc,def
        ghi,jkl
)

warn=(
        abc,def,ghi
        jkl,mno,pqr
)

# use the arrays to avoid warnings for that
echo "${nowarn[@]}"
echo "${warn[@]}"
```
## Behavior before
- only the second example is caught
```
I leaf@Sequoia ~/shellcheck (issue_1318_single_comma_array=)> shellcheck /tmp/example.sh

In /tmp/example.sh line 8:
warn=(
     ^-- SC2054: Use spaces, not commas, to separate array elements.

For more information:
  https://www.shellcheck.net/wiki/SC2054 -- Use spaces, not commas, to separa...
```

## Behavior after
- both examples are caught
```
I leaf@Sequoia ~/shellcheck (issue_1318_single_comma_array=)> stack exec -- shellcheck /tmp/example.sh

In /tmp/example.sh line 3:
nowarn=(
       ^-- SC2054: Use spaces, not commas, to separate array elements.


In /tmp/example.sh line 8:
warn=(
     ^-- SC2054: Use spaces, not commas, to separate array elements.

For more information:
  https://www.shellcheck.net/wiki/SC2054 -- Use spaces, not commas, to separa...