### PR TITLE
Issue 837 flag to include only certain warnings

### DIFF
--- a/shellcheck.1.md
+++ b/shellcheck.1.md
@@ -44,6 +44,13 @@ not warn at all, as `ksh` supports decimals in arithmetic contexts.
     is *auto*. **--color** without an argument is equivalent to
     **--color=always**.
 
+**-i**\ *CODE1*[,*CODE2*...],\ **--include=***CODE1*[,*CODE2*...]
+
+:   Explicitly include only the specified codes in the report. Subsequent **-i**
+    options are cumulative, but all the codes can be specified at once,
+    comma-separated as a single argument. Include options override any provided
+    exclude options.
+
 **-e**\ *CODE1*[,*CODE2*...],\ **--exclude=***CODE1*[,*CODE2*...]
 
 :   Explicitly exclude the specified codes from the report. Subsequent **-e**

--- a/shellcheck.hs
+++ b/shellcheck.hs
@@ -87,6 +87,8 @@ options = [
     Option "C" ["color"]
         (OptArg (maybe (Flag "color" "always") (Flag "color")) "WHEN")
         "Use color (auto, always, never)",
+    Option "i" ["include"]
+        (ReqArg (Flag "include") "CODE1,CODE2..") "Consider only given types of warnings",
     Option "e" ["exclude"]
         (ReqArg (Flag "exclude") "CODE1,CODE2..") "Exclude types of warnings",
     Option "f" ["format"]
@@ -267,6 +269,18 @@ parseOption flag options =
             return options {
                 checkSpec = (checkSpec options) {
                     csExcludedWarnings = new ++ old
+                }
+            }
+
+        Flag "include" str -> do
+            new <- mapM parseNum $ filter (not . null) $ split ',' str
+            let old = csIncludedWarnings . checkSpec $ options
+            return options {
+                checkSpec = (checkSpec options) {
+                    csIncludedWarnings =
+                      if null new
+                        then old
+                        else Just new `mappend` old
                 }
             }
 

--- a/src/ShellCheck/Checker.hs
+++ b/src/ShellCheck/Checker.hs
@@ -94,11 +94,13 @@ checkScript sys spec = do
             (parseMessages ++ map translator analysisMessages)
 
     shouldInclude pc =
-        let code     = cCode (pcComment pc)
+            severity <= csMinSeverity spec &&
+            case csIncludedWarnings spec of
+                Nothing -> code `notElem` csExcludedWarnings spec
+                Just includedWarnings -> code `elem` includedWarnings
+        where
+            code     = cCode (pcComment pc)
             severity = cSeverity (pcComment pc)
-        in
-            code `notElem` csExcludedWarnings spec &&
-            severity <= csMinSeverity spec
 
     sortMessages = sortBy (comparing order)
     order pc =
@@ -134,6 +136,13 @@ checkRecursive includes src =
     checkWithSpec includes emptyCheckSpec {
         csScript = src,
         csExcludedWarnings = [2148],
+        csCheckSourced = True
+    }
+
+checkOptionIncludes includes src =
+    checkWithSpec [] emptyCheckSpec {
+        csScript = src,
+        csIncludedWarnings = includes,
         csCheckSourced = True
     }
 
@@ -274,6 +283,21 @@ prop_sourcedFileUsesOriginalShellExtension = result == [2079]
         csCheckSourced = True
     }
 
+prop_optionIncludes1 =
+    -- expect 2086, but not included, so not reported
+    null $ checkOptionIncludes (Just [2080]) "#!/bin/sh\n var='a b'\n echo $var"
+
+prop_optionIncludes2 =
+    -- expect 2086, included, so its reported
+    [2086] == checkOptionIncludes (Just [2086]) "#!/bin/sh\n var='a b'\n echo $var"
+
+prop_optionIncludes3 =
+    -- expect 2086, no inclusions provided, so its reported
+    [2086] == checkOptionIncludes Nothing "#!/bin/sh\n var='a b'\n echo $var"
+
+prop_optionIncludes4 =
+    -- expect 2086 & 2154, only 2154 included, so only its reported
+    [2154] == checkOptionIncludes (Just [2154]) "#!/bin/sh\n var='a b'\n echo $var\n echo $bar"
 
 return []
 runTests = $quickCheckAll

--- a/src/ShellCheck/Interface.hs
+++ b/src/ShellCheck/Interface.hs
@@ -21,7 +21,7 @@
 module ShellCheck.Interface
     (
     SystemInterface(..)
-    , CheckSpec(csFilename, csScript, csCheckSourced, csExcludedWarnings, csShellTypeOverride, csMinSeverity)
+    , CheckSpec(csFilename, csScript, csCheckSourced, csIncludedWarnings, csExcludedWarnings, csShellTypeOverride, csMinSeverity)
     , CheckResult(crFilename, crComments)
     , ParseSpec(psFilename, psScript, psCheckSourced, psShellTypeOverride)
     , ParseResult(prComments, prTokenPositions, prRoot)
@@ -80,6 +80,7 @@ data CheckSpec = CheckSpec {
     csScript :: String,
     csCheckSourced :: Bool,
     csExcludedWarnings :: [Integer],
+    csIncludedWarnings :: Maybe [Integer],
     csShellTypeOverride :: Maybe Shell,
     csMinSeverity :: Severity
 } deriving (Show, Eq)
@@ -101,6 +102,7 @@ emptyCheckSpec = CheckSpec {
     csScript = "",
     csCheckSourced = False,
     csExcludedWarnings = [],
+    csIncludedWarnings = Nothing,
     csShellTypeOverride = Nothing,
     csMinSeverity = StyleC
 }


### PR DESCRIPTION
Issue https://github.com/koalaman/shellcheck/issues/837

Add an --include option, which creates a whitelist of warnings to report
on, the opposite of --exclude.

# Help text
```
stack exec -- shellcheck --help
Usage: shellcheck [OPTIONS...] FILES...
  -a                --check-sourced          Include warnings from sourced files
  -C[WHEN]          --color[=WHEN]           Use color (auto, always, never)
  -i CODE1,CODE2..  --include=CODE1,CODE2..  Consider only given types of warnings
  -e CODE1,CODE2..  --exclude=CODE1,CODE2..  Exclude types of warnings
  -f FORMAT         --format=FORMAT          Output format (checkstyle, gcc, json, tty)
  -s SHELLNAME      --shell=SHELLNAME        Specify dialect (sh, bash, dash, ksh)
  -S SEVERITY       --severity=SEVERITY      Minimum severity of errors to consider (error, warning, info, style)
  -V                --version                Print version information
  -W NUM            --wiki-link-count=NUM    The number of wiki links to show, when applicable
  -x                --external-sources       Allow 'source' outside of FILES
                    --help                   Show this usage summary and exit
```
# Testing
```
$ stack test
...
ShellCheck-0.6.0: Test suite test-shellcheck passed
Completed 2 action(s).
```

- normal behavior
```
$ cat /tmp/example.sh
#!/bin/bash

var='hello there'
echo $var

while [[ $1 ]]; do
  echo "$1"
  shift
done

$ stack exec -- shellcheck /tmp/example.sh

In /tmp/example.sh line 4:
echo $var
     ^--^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean:
echo "$var"

In /tmp/example.sh line 6:
while [[ $1 ]]; do
         ^-- SC2244: Prefer explicit -n to check non-empty string (or use =/-ne to check boolean/integer).

Did you mean:
while [[ -n $1 ]]; do

For more information:
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
  https://www.shellcheck.net/wiki/SC2244 -- Prefer explicit -n to check non-e...
```
- exclusion behaves as before
```
$ stack exec -- shellcheck -e 2086 -e 2244 /tmp/example.sh
```
```
$ stack exec -- shellcheck -e 2086 /tmp/example.sh

In /tmp/example.sh line 6:
while [[ $1 ]]; do
         ^-- SC2244: Prefer explicit -n to check non-empty string (or use =/-ne to check boolean/integer).

Did you mean:
while [[ -n $1 ]]; do

For more information:
  https://www.shellcheck.net/wiki/SC2244 -- Prefer explicit -n to check non-e...
```
- new inclusion behavior
```
$ stack exec -- shellcheck -i 2086 /tmp/example.sh

In /tmp/example.sh line 4:
echo $var
     ^--^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean:
echo "$var"

For more information:
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
```
```
stack exec -- shellcheck -i 2086 -i 2244 /tmp/example.sh

In /tmp/example.sh line 4:
echo $var
     ^--^ SC2086: Double quote to prevent globbing and word splitting.

Did you mean:
echo "$var"


In /tmp/example.sh line 6:
while [[ $1 ]]; do
         ^-- SC2244: Prefer explicit -n to check non-empty string (or use =/-ne to check boolean/integer).

Did you mean:
while [[ -n $1 ]]; do

For more information:
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
  https://www.shellcheck.net/wiki/SC2244 -- Prefer explicit -n to check non-e...
```