### PR TITLE
Add bats support

### DIFF
--- a/src/ShellCheck/AST.hs
+++ b/src/ShellCheck/AST.hs
@@ -139,6 +139,7 @@ data Token =
     | T_CoProcBody Id Token
     | T_Include Id Token
     | T_SourceCommand Id Token Token
+    | T_BatsTest Id Token Token
     deriving (Show)
 
 data Annotation =
@@ -276,6 +277,7 @@ analyze f g i =
     delve (T_CoProcBody id t) = d1 t $ T_CoProcBody id
     delve (T_Include id script) = d1 script $ T_Include id
     delve (T_SourceCommand id includer t_include) = d2 includer t_include $ T_SourceCommand id
+    delve (T_BatsTest id name t) = d2 name t $ T_BatsTest id
     delve t = return t
 
 getId :: Token -> Id
@@ -380,6 +382,7 @@ getId t = case t of
         T_UnparsedIndex id _ _ -> id
         TC_Empty id _ -> id
         TA_Variable id _ _ -> id
+        T_BatsTest id _ _ -> id
 
 blank :: Monad m => Token -> m ()
 blank = const $ return ()

--- a/src/ShellCheck/Data.hs
+++ b/src/ShellCheck/Data.hs
@@ -109,6 +109,7 @@ shellForExecutable name =
     case name of
         "sh"    -> return Sh
         "bash"  -> return Bash
+        "bats"  -> return Bash
         "dash"  -> return Dash
         "ash"   -> return Dash -- There's also a warning for this.
         "ksh"   -> return Ksh

--- a/src/ShellCheck/Parser.hs
+++ b/src/ShellCheck/Parser.hs
@@ -2331,6 +2331,17 @@ readBraceGroup = called "brace group" $ do
     id <- endSpan start
     return $ T_BraceGroup id list
 
+prop_readBatsTest = isOk readBatsTest "@test 'can parse' {\n  true\n}"
+readBatsTest = called "bats @test" $ do
+    start <- startSpan
+    try $ string "@test"
+    spacing
+    name <- readNormalWord
+    spacing
+    test <- readBraceGroup
+    id <- endSpan start
+    return $ T_BatsTest id name test
+
 prop_readWhileClause = isOk readWhileClause "while [[ -e foo ]]; do sleep 1; done"
 readWhileClause = called "while loop" $ do
     start <- startSpan
@@ -2590,6 +2601,7 @@ readCompoundCommand = do
         readForClause,
         readSelectClause,
         readCaseClause,
+        readBatsTest,
         readFunctionDefinition
         ]
     spacing
@@ -3037,6 +3049,7 @@ readScriptFile = do
         "ash",
         "dash",
         "bash",
+        "bats",
         "ksh"
         ]
     badShells = [


### PR DESCRIPTION
This is motivated by the fact that the popularity of bats is increasing
since the creation of bats-core/bats-core.

The code is a cherry-pick of [koalaman/shellcheck/bats](/koalaman/shellcheck/tree/bats/) branch.

Fix koalaman/shellcheck#417.