### PR TITLE
Add: GitLab Support on Install

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,6 @@ On Debian based distros:
 On Arch Linux based distros:
 
     pacman -S shellcheck
-    
 or get the dependency free [shellcheck-static](https://aur.archlinux.org/packages/shellcheck-static/) from the AUR.
 
 On Gentoo based distros:

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ On Debian based distros:
 On Arch Linux based distros:
 
     pacman -S shellcheck
-
+    
 or get the dependency free [shellcheck-static](https://aur.archlinux.org/packages/shellcheck-static/) from the AUR.
 
 On Gentoo based distros:
@@ -177,9 +177,10 @@ Distro packages already come with a `man` page. If you are building from source,
     pandoc -s -t man shellcheck.1.md -o shellcheck.1
     sudo mv shellcheck.1 /usr/share/man/man1
 
-## Travis CI
+## Travis CI & GitLab
 
-Travis CI has now integrated ShellCheck by default, so you don't need to manually install it.
+Travis CI has now intergrated ShellCheck by default, so you don't need to manually install it.
+GitLab does not intergrate ShellCheck by default, so you need to manually install it or pick what distro package to use.
 
 If you still want to do so in order to upgrade at your leisure or ensure the latest release, follow the steps to install the shellcheck binary, bellow.
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Distro packages already come with a `man` page. If you are building from source,
 ## Travis CI & GitLab
 
 Travis CI has now intergrated ShellCheck by default, so you don't need to manually install it.
+
 GitLab does not intergrate ShellCheck by default, so you need to manually install it or pick what distro package to use.
 
 If you still want to do so in order to upgrade at your leisure or ensure the latest release, follow the steps to install the shellcheck binary, bellow.


### PR DESCRIPTION
Directions for using GitLab are similar to Travis CLI. This hopefully clears up on how to install it on GitLab.