### PR TITLE
Fix issues #896 and #433: printf -v and arrays

### DIFF
--- a/src/ShellCheck/Analytics.hs
+++ b/src/ShellCheck/Analytics.hs
@@ -1954,6 +1954,7 @@ prop_checkUnassignedReferences33= verifyNotTree checkUnassignedReferences "f() {
 prop_checkUnassignedReferences34= verifyNotTree checkUnassignedReferences "declare -A foo; (( foo[bar] ))"
 prop_checkUnassignedReferences35= verifyNotTree checkUnassignedReferences "echo ${arr[foo-bar]:?fail}"
 prop_checkUnassignedReferences36= verifyNotTree checkUnassignedReferences "read -a foo -r <<<\"foo bar\"; echo \"$foo\""
+prop_checkUnassignedReferences37= verifyNotTree checkUnassignedReferences "var=howdy; printf -v 'array[0]' %s \"$var\"; printf %s \"${array[0]}\";"
 checkUnassignedReferences params t = warnings
   where
     (readMap, writeMap) = execState (mapM tally $ variableFlow params) (Map.empty, Map.empty)

--- a/src/ShellCheck/AnalyzerLib.hs
+++ b/src/ShellCheck/AnalyzerLib.hs
@@ -649,7 +649,11 @@ getModifiedVariableCommand base@(T_SimpleCommand _ _ (T_NormalWord _ (T_Literal 
 
     getPrintfVariable list = f $ map (\x -> (x, getLiteralString x)) list
       where
-        f ((_, Just "-v") : (t, Just var) : _) = return (base, t, var, DataString $ SourceFrom list)
+        f ((_, Just "-v") : (t, Just var) : _) = return (base, t, varName, varType $ SourceFrom list)
+            where
+                (varName, varType) = case elemIndex '[' var of
+                    Just i -> (take i var, DataArray)
+                    Nothing -> (var, DataString)
         f (_:rest) = f rest
         f [] = fail "not found"
 


### PR DESCRIPTION
Now ShellCheck recognises array variables assigned by `printf -v`.

# Testing
`stack build && stack test`
```
=== prop_checkUnassignedReferences37 from src/ShellCheck/Analytics.hs:1957 ===
+++ OK, passed 1 tests.
...
ShellCheck-0.6.0: Test suite test-shellcheck passed
Completed 2 action(s).
```
