### PR TITLE
Add option to look for sources in alternate root paths

### DIFF
--- a/src/ShellCheck/Interface.hs
+++ b/src/ShellCheck/Interface.hs
@@ -73,6 +73,8 @@ import qualified Data.Map as Map
 data SystemInterface m = SystemInterface {
     -- Read a file by filename, or return an error
     siReadFile :: String -> m (Either ErrorMessage String),
+    -- Find source file in alternate root paths
+    siFindSource :: String -> m (FilePath),
     -- Get the configuration file (name, contents) for a filename
     siGetConfig :: String -> m (Maybe (FilePath, String))
 }
@@ -287,6 +289,7 @@ data ColorOption =
 mockedSystemInterface :: [(String, String)] -> SystemInterface Identity
 mockedSystemInterface files = SystemInterface {
     siReadFile = rf,
+    siFindSource = fs,
     siGetConfig = const $ return Nothing
 }
   where
@@ -294,6 +297,7 @@ mockedSystemInterface files = SystemInterface {
         case filter ((== file) . fst) files of
             [] -> return $ Left "File not included in mock."
             [(_, contents)] -> return $ Right contents
+    fs file = return file
 
 mockRcFile rcfile mock = mock {
     siGetConfig = const . return $ Just (".shellcheckrc", rcfile)

--- a/src/ShellCheck/Parser.hs
+++ b/src/ShellCheck/Parser.hs
@@ -2087,7 +2087,9 @@ readSource t@(T_Redirecting _ _ (T_SimpleCommand cmdId _ (cmd:file':rest'))) = d
                 input <-
                     if filename == "/dev/null" -- always allow /dev/null
                     then return (Right "")
-                    else system $ siReadFile sys filename
+                    else do
+                        filename' <- system $ siFindSource sys filename
+                        system $ siReadFile sys filename'
                 case input of
                     Left err -> do
                         parseNoteAtId (getId file) InfoC 1091 $


### PR DESCRIPTION
Add a new optional flag `-r|--root ROOTPATHS`, where `ROOTPATHS` is a colon separated list of paths, that will look for external sources in alternate roots.

This is particular useful when the run-time environment does not fully match the development environment. The `#shellcheck source=file` directive is useful, but has its limitations in certain scenarios. Also, in many cases the directive could be removed from scripts when the root flag is used.

Script example.bash:
```bash
#!/bin/bash
source /etc/foo/config
```

Example usage where `etc/foo/config` exists in `skel/foo`:
```bash
shellcheck -x -r skel/foo:skel/core example.bash
```