### PR TITLE
Allow variable tabstop widths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
                    Enable with `-o` flags or `enable=name` directives
 - Source paths: Use `-P dir1:dir2` or a `source-path=dir1` directive
                 to specify search paths for sourced files.
+- json1 format like --format=json but treats tabs as single characters
 - SC2249: Warn about `case` with missing default case (verbose)
 - SC2248: Warn about unquoted variables without special chars (verbose)
 - SC2247: Warn about $"(cmd)" and $"{var}"

--- a/shellcheck.1.md
+++ b/shellcheck.1.md
@@ -153,7 +153,7 @@ not warn at all, as `ksh` supports decimals in arithmetic contexts.
 
 :   Json is a popular serialization format that is more suitable for web
     applications. ShellCheck's json is compact and contains only the bare
-    minimum.
+    minimum.  Tabs are 8 characters.
 
         [
           {
@@ -166,6 +166,11 @@ not warn at all, as `ksh` supports decimals in arithmetic contexts.
           },
           ...
         ]
+
+**json1**
+
+:   This is the same as shellcheck's json format, but tabs are treated as
+    single characters instead of 8-character tabstops.
 
 *quiet*
 

--- a/shellcheck.hs
+++ b/shellcheck.hs
@@ -141,7 +141,8 @@ formats :: FormatterOptions -> Map.Map String (IO Formatter)
 formats options = Map.fromList [
     ("checkstyle", ShellCheck.Formatter.CheckStyle.format),
     ("gcc",  ShellCheck.Formatter.GCC.format),
-    ("json", ShellCheck.Formatter.JSON.format),
+    ("json", ShellCheck.Formatter.JSON.format False),  -- JSON with 8-char tabs
+    ("json1", ShellCheck.Formatter.JSON.format True), -- JSON with 1-char tabs
     ("tty",  ShellCheck.Formatter.TTY.format options),
     ("quiet",  ShellCheck.Formatter.Quiet.format options)
     ]

--- a/src/ShellCheck/Formatter/Format.hs
+++ b/src/ShellCheck/Formatter/Format.hs
@@ -22,6 +22,7 @@ module ShellCheck.Formatter.Format where
 import ShellCheck.Data
 import ShellCheck.Interface
 import ShellCheck.Fixer
+import Control.Monad
 import Data.Array
 
 -- A formatter that carries along an arbitrary piece of data
@@ -54,5 +55,10 @@ makeNonVirtual comments contents =
   where
     list = lines contents
     arr = listArray (1, length list) list
-    fix c = removeTabStops c arr
+    untabbedFix f = newFix {
+      fixReplacements = map (\r -> removeTabStops r arr) (fixReplacements f)
+    }
+    fix c = (removeTabStops c arr) {
+      pcFix = liftM untabbedFix (pcFix c)
+    }
 


### PR DESCRIPTION
Add a new -t option to specify the output width of tabstops, with a
default of 8 to match the current behavior.  Convert formatters that
currently use hardcoded 8-character tabstops (TTY and JSON) to respect
the new -t option.

This has two main use cases:
  1. Allow editors to pass -fjson -t1 so that they can consume the json
     output in a character-oriented way without breaking backwards
     compatibility.
  2. Allow users with narrow terminals to run
     shellcheck -tN | expand -tN
     to fit more levels of indentation on the screen.

Also addresses #1048.