### PR TITLE
Add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+*
+!LICENSE
+!Setup.hs
+!ShellCheck.cabal
+!shellcheck.hs
+!src


### PR DESCRIPTION
This explicitly defines included/copied files, to reduce the context
being sent to the Docker daemon initially.

Feel free to close this without merging - it is probably not as relevant as with e.g. Python projects where you would have `.venv` etc, and adds some maintenance overhead when using/copying new files.