### PR TITLE
Add portage bash dialect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - json1 format like --format=json but treats tabs as single characters
 - Recognize FLAGS variables created by the shflags library.
 - Site-specific changes can now be made in Custom.hs for ease of patching
+- Add portage as a bash-like shell for ebuild/eclass files.
 - SC2154: Also warn about unassigned uppercase variables (optional)
 - SC2252: Warn about `[ $a != x ] || [ $a != y ]`, similar to SC2055
 - SC2251: Inform about ineffectual ! in front of commands

--- a/shellcheck.1.md
+++ b/shellcheck.1.md
@@ -87,8 +87,9 @@ not warn at all, as `ksh` supports decimals in arithmetic contexts.
 
 :   Specify Bourne shell dialect. Valid values are *sh*, *bash*, *dash* and *ksh*.
     The default is to deduce the shell from the file's `shell` directive,
-    shebang, or `.bash/.bats/.dash/.ksh` extension, in that order. *sh* refers to
-    POSIX `sh` (not the system's), and will warn of portability issues.
+    shebang, or `.bash/.bats/.dash/.ksh/.ebuild/.eclass` extension, in that
+    order. *sh* refers to POSIX `sh` (not the system's), and will warn of
+    portability issues.
 
 **-S**\ *SEVERITY*,\ **--severity=***severity*
 

--- a/src/ShellCheck/Analytics.hs
+++ b/src/ShellCheck/Analytics.hs
@@ -2815,14 +2815,15 @@ checkUncheckedCdPushdPopd params root =
             && not (name `elem` ["pushd", "popd"] && ("n" `elem` map snd (getAllFlags t)))
             && not (isCondition $ getPath (parentMap params) t)) $
                 warnWithFix (getId t) 2164
-                    ("Use '" ++ name ++ " ... || exit' or '" ++ name ++ " ... || return' in case " ++ name ++ " fails.")
-                    (fixWith [replaceEnd (getId t) params 0 " || exit"])
+                    ("Use '" ++ name ++ " ... || " ++ exit ++ "' or '" ++ name ++ " ... || return' in case " ++ name ++ " fails.")
+                    (fixWith [replaceEnd (getId t) params 0 (" || " ++ exit)])
     checkElement _ = return ()
     getName t = fromMaybe "" $ getCommandName t
     isSafeDir t = case oversimplify t of
           [_, str] -> str `matches` regex
           _ -> False
     regex = mkRegex "^/*((\\.|\\.\\.)/+)*(\\.|\\.\\.)?$"
+    exit = if isPortageBuild params then "die" else "exit"
 
 prop_checkLoopVariableReassignment1 = verify checkLoopVariableReassignment "for i in *; do for i in *.bar; do true; done; done"
 prop_checkLoopVariableReassignment2 = verify checkLoopVariableReassignment "for i in *; do for((i=0; i<3; i++)); do true; done; done"

--- a/src/ShellCheck/Analytics.hs
+++ b/src/ShellCheck/Analytics.hs
@@ -2758,7 +2758,6 @@ prop_checkMaskedReturns2 = verify checkMaskedReturns "declare a=$(false)"
 prop_checkMaskedReturns3 = verify checkMaskedReturns "declare a=\"`false`\""
 prop_checkMaskedReturns4 = verifyNot checkMaskedReturns "declare a; a=$(false)"
 prop_checkMaskedReturns5 = verifyNot checkMaskedReturns "f() { local -r a=$(false); }"
-prop_checkMaskedReturns6 = verifyNot checkMaskedReturns "#shellcheck shell=portage\ndeclare a=$(false)"
 checkMaskedReturns params t@(T_SimpleCommand id _ (cmd:rest)) = potentially $ do
     name <- getCommandName t
     guard $ (name `elem` ["declare", "export"]

--- a/src/ShellCheck/Analytics.hs
+++ b/src/ShellCheck/Analytics.hs
@@ -2745,10 +2745,12 @@ prop_checkMaskedReturns2 = verify checkMaskedReturns "declare a=$(false)"
 prop_checkMaskedReturns3 = verify checkMaskedReturns "declare a=\"`false`\""
 prop_checkMaskedReturns4 = verifyNot checkMaskedReturns "declare a; a=$(false)"
 prop_checkMaskedReturns5 = verifyNot checkMaskedReturns "f() { local -r a=$(false); }"
-checkMaskedReturns _ t@(T_SimpleCommand id _ (cmd:rest)) = potentially $ do
+prop_checkMaskedReturns6 = verifyNot checkMaskedReturns "#shellcheck shell=portage\ndeclare a=$(false)"
+checkMaskedReturns params t@(T_SimpleCommand id _ (cmd:rest)) = potentially $ do
     name <- getCommandName t
-    guard $ name `elem` ["declare", "export"]
-        || name == "local" && "r" `notElem` map snd (getAllFlags t)
+    guard $ (name `elem` ["declare", "export"]
+        || name == "local" && "r" `notElem` map snd (getAllFlags t))
+        && (not $ isPortageBuild params)
     return $ mapM_ checkArgs rest
   where
     checkArgs (T_Assignment id _ _ _ word) | any hasReturn $ getWordParts word =

--- a/src/ShellCheck/AnalyzerLib.hs
+++ b/src/ShellCheck/AnalyzerLib.hs
@@ -92,7 +92,9 @@ data Parameters = Parameters {
     -- The root node of the AST
     rootNode           :: Token,
     -- map from token id to start and end position
-    tokenPositions     :: Map.Map Id (Position, Position)
+    tokenPositions     :: Map.Map Id (Position, Position),
+    -- True if script is being used as a portage build file
+    isPortageBuild     :: Bool
     } deriving (Show)
 
 -- TODO: Cache results of common AST ops here
@@ -195,7 +197,8 @@ makeParameters spec =
         shellTypeSpecified = isJust (asShellType spec) || isJust (asFallbackShell spec),
         parentMap = getParentTree root,
         variableFlow = getVariableFlow params root,
-        tokenPositions = asTokenPositions spec
+        tokenPositions = asTokenPositions spec,
+        isPortageBuild = asIsPortageBuild spec
     } in params
   where root = asScript spec
 

--- a/src/ShellCheck/Checker.hs
+++ b/src/ShellCheck/Checker.hs
@@ -53,11 +53,17 @@ shellFromFilename filename = foldl mplus Nothing candidates
     shellExtensions = [(".ksh", Ksh)
                       ,(".bash", Bash)
                       ,(".bats", Bash)
-                      ,(".dash", Dash)]
+                      ,(".dash", Dash)
+                      ,(".ebuild", Bash)
+                      ,(".eclass", Bash)]
                       -- The `.sh` is too generic to determine the shell:
                       -- We fallback to Bash in this case and emit SC2148 if there is no shebang
     candidates =
         map (\(ext,sh) -> if ext `isSuffixOf` filename then Just sh else Nothing) shellExtensions
+
+isPortageBuildFile filename = any (\x -> isSuffixOf x filename) portageExtensions
+  where
+    portageExtensions = [".ebuild", ".eclass"]
 
 checkScript :: Monad m => SystemInterface m -> CheckSpec -> m CheckResult
 checkScript sys spec = do
@@ -85,7 +91,8 @@ checkScript sys spec = do
                     asCheckSourced = csCheckSourced spec,
                     asExecutionMode = Executed,
                     asTokenPositions = tokenPositions,
-                    asOptionalChecks = csOptionalChecks spec
+                    asOptionalChecks = csOptionalChecks spec,
+                    asIsPortageBuild = isPortageBuildFile $ csFilename spec
                 } where as = newAnalysisSpec root
         let analysisMessages =
                 fromMaybe [] $

--- a/src/ShellCheck/Data.hs
+++ b/src/ShellCheck/Data.hs
@@ -6,7 +6,7 @@ import Paths_ShellCheck (version)
 
 shellcheckVersion = showVersion version
 
-internalVariables = [
+genericInternalVariables = [
     -- Generic
     "", "_", "rest", "REST",
 
@@ -34,19 +34,34 @@ internalVariables = [
     "USER", "TZ", "TERM", "LOGNAME", "LD_LIBRARY_PATH", "LANGUAGE", "DISPLAY",
     "HOSTNAME", "KRB5CCNAME", "XAUTHORITY"
 
-    -- Ksh
-    , ".sh.version"
-
     -- shflags
     , "FLAGS_ARGC", "FLAGS_ARGV", "FLAGS_ERROR", "FLAGS_FALSE", "FLAGS_HELP",
     "FLAGS_PARENT", "FLAGS_RESERVED", "FLAGS_TRUE", "FLAGS_VERSION",
     "flags_error", "flags_return"
   ]
 
+kshInternalVariables = [
+    ".sh.version"
+  ]
+
+portageInternalVariables = [
+    "A", "BDEPEND", "BROOT", "CATEGORY", "D", "DEPEND", "DESCRIPTION",
+    "DISTDIR", "DOCS", "EAPI", "ED", "EPREFIX", "EROOT", "ESYSROOT", "FILESDIR",
+    "HOME", "HOMEPAGE", "HTML_DOCS", "IUSE", "KEYWORDS", "LICENSE", "P",
+    "PATCHES", "PDEPEND", "PF", "PN", "PR", "PROPERTIES", "PV", "PVR",
+    "QA_AM_MAINTAINER_MODE", "QA_CONFIGURE_OPTIONS", "QA_DESKTOP_FILE",
+    "QA_DT_NEEDED", "QA_EXECSTACK", "QA_FLAGS_IGNORED", "QA_MULTILIB_PATHS",
+    "QA_PREBUILT", "QA_PRESTRIPPED", "QA_SONAME", "QA_SONAME_NO_SYMLINK",
+    "QA_TEXTRELS", "QA_WX_LOAD", "RDEPEND", "REQUIRED_USE", "RESTRICT", "ROOT",
+    "S", "SLOT", "SRC_TEST", "SRC_URI", "STRIP_MASK", "SUBSLOT", "SYSROOT",
+    "T", "WORKDIR"
+  ]
+
 specialVariablesWithoutSpaces = [
     "$", "-", "?", "!", "#"
   ]
-variablesWithoutSpaces = specialVariablesWithoutSpaces ++ [
+
+shellVariablesWithoutSpaces = specialVariablesWithoutSpaces ++ [
     "BASHPID", "BASH_ARGC", "BASH_LINENO", "BASH_SUBSHELL", "EUID", "LINENO",
     "OPTIND", "PPID", "RANDOM", "SECONDS", "SHELLOPTS", "SHLVL", "UID",
     "COLUMNS", "HISTFILESIZE", "HISTSIZE", "LINES"
@@ -55,16 +70,24 @@ variablesWithoutSpaces = specialVariablesWithoutSpaces ++ [
     , "FLAGS_ERROR", "FLAGS_FALSE", "FLAGS_TRUE"
   ]
 
+portageVariablesWithoutSpaces = [
+    "EAPI", "P", "PF", "PN", "PR", "PV", "PVR", "SLOT"
+  ]
+
 specialVariables = specialVariablesWithoutSpaces ++ ["@", "*"]
 
 unbracedVariables = specialVariables ++ [
     "0", "1", "2", "3", "4", "5", "6", "7", "8", "9"
   ]
 
-arrayVariables = [
+shellArrayVariables = [
     "BASH_ALIASES", "BASH_ARGC", "BASH_ARGV", "BASH_CMDS", "BASH_LINENO",
     "BASH_REMATCH", "BASH_SOURCE", "BASH_VERSINFO", "COMP_WORDS", "COPROC",
     "DIRSTACK", "FUNCNAME", "GROUPS", "MAPFILE", "PIPESTATUS", "COMPREPLY"
+  ]
+
+portageArrayVariables = [
+    "PATCHES"
   ]
 
 commonCommands = [

--- a/src/ShellCheck/Interface.hs
+++ b/src/ShellCheck/Interface.hs
@@ -25,7 +25,7 @@ module ShellCheck.Interface
     , CheckResult(crFilename, crComments)
     , ParseSpec(psFilename, psScript, psCheckSourced, psIgnoreRC, psShellTypeOverride)
     , ParseResult(prComments, prTokenPositions, prRoot)
-    , AnalysisSpec(asScript, asShellType, asFallbackShell, asExecutionMode, asCheckSourced, asTokenPositions, asOptionalChecks)
+    , AnalysisSpec(asScript, asShellType, asFallbackShell, asExecutionMode, asCheckSourced, asTokenPositions, asOptionalChecks, asIsPortageBuild)
     , AnalysisResult(arComments)
     , FormatterOptions(foColorOption, foWikiLinkCount)
     , Shell(Ksh, Sh, Bash, Dash)
@@ -161,7 +161,8 @@ data AnalysisSpec = AnalysisSpec {
     asExecutionMode :: ExecutionMode,
     asCheckSourced :: Bool,
     asOptionalChecks :: [String],
-    asTokenPositions :: Map.Map Id (Position, Position)
+    asTokenPositions :: Map.Map Id (Position, Position),
+    asIsPortageBuild :: Bool
 }
 
 newAnalysisSpec token = AnalysisSpec {
@@ -171,7 +172,8 @@ newAnalysisSpec token = AnalysisSpec {
     asExecutionMode = Executed,
     asCheckSourced = False,
     asOptionalChecks = [],
-    asTokenPositions = Map.empty
+    asTokenPositions = Map.empty,
+    asIsPortageBuild = False
 }
 
 newtype AnalysisResult = AnalysisResult {


### PR DESCRIPTION
Gentoo's portage package manager is built around bash, but with some specific constraints on the environment where the scripts run and a bunch of additional global data.  We can mostly lint it as bash, but it's helpful to be able to have some behavior differences without passing tons of command-line options.

This adds portage as a new shell that should be initially identical to bash, and then turns off one warning as an example of something that could work differently.  If the general approach is reasonable, we'll send more portage-specific changes.