### PR TITLE
Fix syntax and indentation in shellcheck.1.md

### DIFF
--- a/shellcheck.1.md
+++ b/shellcheck.1.md
@@ -157,16 +157,16 @@ not warn at all, as `ksh` supports decimals in arithmetic contexts.
 :   Auto-fixes in unified diff format. Can be piped to `git apply` or `patch -p1`
     to automatically apply fixes.
 
-    --- a/test.sh
-    +++ b/test.sh
-    @@ -2,6 +2,6 @@
-     ## Example of a broken script.
-     for f in $(ls *.m3u)
-     do
-    -  grep -qi hq.*mp3 $f \
-    +  grep -qi hq.*mp3 "$f" \
-	 && echo -e 'Playlist $f contains a HQ file in mp3 format'
-     done
+        --- a/test.sh
+        +++ b/test.sh
+        @@ -2,6 +2,6 @@
+         ## Example of a broken script.
+         for f in $(ls *.m3u)
+         do
+        -  grep -qi hq.*mp3 $f \
+        +  grep -qi hq.*mp3 "$f" \
+             && echo -e 'Playlist $f contains a HQ file in mp3 format'
+         done
 
 
 **json1**


### PR DESCRIPTION
Out of interest, I ran the command

    pandoc -s -f markdown-smart -t man shellcheck.1.md -o shellcheck.1

locally, but that produces warnings (previous to this commit).  Checking
the generated manpage, I found the diff to be rendered very badly.
(Broken at terminal width like a normal paragraph).  This commit fixes
the problem.