### PR TITLE
Add reviewdog/action-shellcheck as a way to run shellcheck on GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Services and platforms that have ShellCheck pre-installed and ready to use:
 Services and platforms with third party plugins:
 
 * [SonarQube](https://www.sonarqube.org/) through [sonar-shellcheck-plugin](https://github.com/emerald-squad/sonar-shellcheck-plugin)
+* [GitHub Actions](https://github.com/features/actions) through [reviewdog/action-shellcheck](https://github.com/reviewdog/action-shellcheck)
 
 Most other services, including [GitLab](https://about.gitlab.com/), let you install
 ShellCheck yourself, either through the system's package manager (see [Installing](#installing)),


### PR DESCRIPTION
Hi @koalaman! Thank you for the great tool!

I created  https://github.com/reviewdog/action-shellcheck which runs shellcheck with [reviewdog](https://github.com/reviewdog/reviewdog).
I added a link in case you think it's worth mentioning it.

### Sample
[![github-pr-review sample](https://user-images.githubusercontent.com/3797062/65700741-1c4faa80-e0bb-11e9-8cbd-9a99aeb38594.png)](https://github.com/reviewdog/action-shellcheck/pull/1)

Please feel free to close it if you don't think so.

Thanks!