### PR TITLE
add github actions link

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Services and platforms that have ShellCheck pre-installed and ready to use:
 * [Codacy](https://www.codacy.com/)
 * [Code Climate](https://codeclimate.com/)
 * [Code Factor](https://www.codefactor.io/)
+* [Github](https://github.com/features/actions)(only Linux)
 
 Services and platforms with third party plugins:
 


### PR DESCRIPTION
shellcheck comes installed by default on github's linux VM

https://help.github.com/en/articles/software-in-virtual-environments-for-github-actions