### PR TITLE
Running quicktest and quickrun through stack

### DIFF
--- a/quickrun
+++ b/quickrun
@@ -2,4 +2,7 @@
 # quickrun runs ShellCheck in an interpreted mode.
 # This allows testing changes without recompiling.
 
-stack runghc shellcheck.hs "$@"
+BASEDIR=$(dirname $0)
+AUTOGEN_PATH=$(find . -path '*/build/autogen')
+
+stack runghc -- -i"${AUTOGEN_PATH}" -isrc shellcheck.hs "$@"

--- a/quickrun
+++ b/quickrun
@@ -2,4 +2,4 @@
 # quickrun runs ShellCheck in an interpreted mode.
 # This allows testing changes without recompiling.
 
-runghc -isrc -idist/build/autogen shellcheck.hs "$@"
+stack runghc shellcheck.hs "$@"

--- a/quicktest
+++ b/quicktest
@@ -4,7 +4,7 @@
 # 'cabal test' remains the source of truth.
 
 (
-var=$(echo 'main' | ghci test/shellcheck.hs 2>&1 | tee /dev/stderr)
+var=$(echo 'main' | stack ghci test/shellcheck.hs 2>&1 | tee /dev/stderr)
 if [[ $var == *ExitSuccess* ]]
 then
   exit 0


### PR DESCRIPTION
executing `runghc` and `ghci` in those scripts without stack causing problems for me, so I use stack to execute those commands instead of running it from local bin.