### PR TITLE
Scarf package manager install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,10 @@ docker run --rm -v "$PWD:/mnt" koalaman/shellcheck:stable myscript
 
 or use `koalaman/shellcheck-alpine` if you want a larger Alpine Linux based image to extend. It works exactly like a regular Alpine image, but has shellcheck preinstalled.
 
+If you'd like to support this project, please consider installing with the [Scarf package manager](https://scarf.sh):
+
+    scarf install shellcheck
+
 Alternatively, you can download pre-compiled binaries for the latest release here:
 
 * [Linux, x86_64](https://storage.googleapis.com/shellcheck/shellcheck-stable.linux.x86_64.tar.xz) (statically linked)


### PR DESCRIPTION
Hi @koalaman! This change adds install instructions with the [Scarf package manager](https://scarf.sh).

Scarf can help support shellcheck by offering usage and runtime statistics as well as a way to take payments from those using the tool in a commercial setting. 

I can transfer package ownership to you or add you as a co-maintainer, though I'll help with package maintenance either way. Should you decide to collect payments on Scarf, I'd gladly be your first customer 😄. I've been using shellcheck for a while so I hope Scarf can help support this project too. 

Thanks!