### PR TITLE
Fix issue #1733 (False negative in SC2155)

### DIFF
--- a/src/ShellCheck/Analytics.hs
+++ b/src/ShellCheck/Analytics.hs
@@ -2788,6 +2788,7 @@ prop_checkMaskedReturns2 = verify checkMaskedReturns "declare a=$(false)"
 prop_checkMaskedReturns3 = verify checkMaskedReturns "declare a=\"`false`\""
 prop_checkMaskedReturns4 = verifyNot checkMaskedReturns "declare a; a=$(false)"
 prop_checkMaskedReturns5 = verifyNot checkMaskedReturns "f() { local -r a=$(false); }"
+prop_checkMaskedReturns6 = verify checkMaskedReturns "V=\"$(false)\" cmd"
 checkMaskedReturns _ t@(T_SimpleCommand id preopts (cmd:rest)) = potentially $ do
     name <- getCommandName t
     guard $ name `elem` ["declare", "export"]

--- a/src/ShellCheck/Analytics.hs
+++ b/src/ShellCheck/Analytics.hs
@@ -2788,11 +2788,12 @@ prop_checkMaskedReturns2 = verify checkMaskedReturns "declare a=$(false)"
 prop_checkMaskedReturns3 = verify checkMaskedReturns "declare a=\"`false`\""
 prop_checkMaskedReturns4 = verifyNot checkMaskedReturns "declare a; a=$(false)"
 prop_checkMaskedReturns5 = verifyNot checkMaskedReturns "f() { local -r a=$(false); }"
-checkMaskedReturns _ t@(T_SimpleCommand id _ (cmd:rest)) = potentially $ do
+checkMaskedReturns _ t@(T_SimpleCommand id preopts (cmd:rest)) = potentially $ do
     name <- getCommandName t
     guard $ name `elem` ["declare", "export"]
         || name == "local" && "r" `notElem` map snd (getAllFlags t)
-    return $ mapM_ checkArgs rest
+        || not (null preopts)
+    return $ mapM_ checkArgs (preopts ++ rest)
   where
     checkArgs (T_Assignment id _ _ _ word) | any hasReturn $ getWordParts word =
         warn id 2155 "Declare and assign separately to avoid masking return values."


### PR DESCRIPTION
test.sh:
```
#!/usr/bin/env bash
set -o errexit
export FOO="$(myEnvBuilder)"
FOO="$(myEnvBuilder)" ./myCmd.sh
```

output of `shellcheck test.sh`:
```
In test.sh line 3:
export FOO="$(myEnvBuilder)"
       ^-^ SC2155: Declare and assign separately to avoid masking return values.


In test.sh line 4:
FOO="$(myEnvBuilder)" ./myCmd.sh
^-^ SC2155: Declare and assign separately to avoid masking return values.

[...]
```
---
`stack test`:
```
[...]
=== prop_checkMaskedReturns6 from src/ShellCheck/Analytics.hs:2791 ===
+++ OK, passed 1 test.
[...]                              
ShellCheck-0.7.0: Test suite test-shellcheck passed
Completed 2 action(s).
```