### PR TITLE
Fix issue #1724 (bash: missing support for 'builtin' keyword)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## v0.7.1 - soon
 ### Fixed
 - `-f diff` no longer claims that it found more issues when it didn't
-- SC2154 triggers for builtins called with `builtin`
+- SC2154 and all command-specific checks now trigger for builtins
+  called with `builtin`
 
 ### Added
 - SC2254: Suggest quoting expansions in case statements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v0.7.1 - soon
 ### Fixed
 - `-f diff` no longer claims that it found more issues when it didn't
+- SC2154 triggers for builtins called with `builtin`
 
 ### Added
 - SC2254: Suggest quoting expansions in case statements

--- a/src/ShellCheck/Analytics.hs
+++ b/src/ShellCheck/Analytics.hs
@@ -2168,6 +2168,7 @@ prop_checkUnassignedReferences35= verifyNotTree checkUnassignedReferences "echo 
 prop_checkUnassignedReferences36= verifyNotTree checkUnassignedReferences "read -a foo -r <<<\"foo bar\"; echo \"$foo\""
 prop_checkUnassignedReferences37= verifyNotTree checkUnassignedReferences "var=howdy; printf -v 'array[0]' %s \"$var\"; printf %s \"${array[0]}\";"
 prop_checkUnassignedReferences38= verifyTree (checkUnassignedReferences' True) "echo $VAR"
+prop_checkUnassignedReferences39= verifyNotTree checkUnassignedReferences "builtin export var=4; echo $var"
 
 checkUnassignedReferences = checkUnassignedReferences' False
 checkUnassignedReferences' includeGlobals params t = warnings

--- a/src/ShellCheck/AnalyzerLib.hs
+++ b/src/ShellCheck/AnalyzerLib.hs
@@ -567,9 +567,11 @@ getReferencedVariableCommand _ = []
 --   VariableName :: String,   -- The variable name, i.e. foo
 --   VariableValue :: DataType -- A description of the value being assigned, i.e. "Literal string with value foo"
 -- )
-getModifiedVariableCommand base@(T_SimpleCommand _ _ (T_NormalWord _ (T_Literal _ x:_):rest)) =
+getModifiedVariableCommand base@(T_SimpleCommand id cmdPrefix (T_NormalWord _ (T_Literal _ x:_):rest)) =
    filter (\(_,_,s,_) -> not ("-" `isPrefixOf` s)) $
     case x of
+        "builtin" ->
+            getModifiedVariableCommand $ T_SimpleCommand id cmdPrefix rest
         "read" ->
             let params = map getLiteral rest
                 readArrayVars = getReadArrayVariables rest


### PR DESCRIPTION
Fix issue #1724 
Now shellcheck recognises read/written variables in builtins called with the 'builtin' keyword. The parser looks at the first argument passed to `builtin` to determine the type of the other arguments so `builtin cmd ...` is parsed in the same way as `cmd ...` and it automatically parses assignments correctly if the builtin is `export`, `declare`, etc.

With the second commit command-specific checks in `ShellCheck.Checks.Command` are applied to commands called with `builtin` in the same vein as the parser.

It might be useful to add a new warning for unknown builtins because as of now `builtin my-strange-cmd-which-isnt-a-builtin` doesn't trigger any. @koalaman if you agree with me, leave a reply on this message and I will add another commit on this pull request.

---
### Testing
`stack test`:

```
[...]
ShellCheck> Test suite test-shellcheck passed
```