### PR TITLE
SC2256: Check for translated strings matching known variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Added
 - SC2254: Suggest quoting expansions in case statements
 - SC2255: Suggest using `$((..))` in `[ 2*3 -eq 6 ]`
+- SC2256: Warn about translated strings that are known variables
 
 ## v0.7.0 - 2019-07-28
 ### Added


### PR DESCRIPTION
SC2247 already warns about translated strings that look like $"(foo)" or
$"{foo}".  Since typical use of translated strings is to translate whole
messages, a string like $"foo" is likely to be a similar mistake if foo
is the name of an existing variable.  Conversely, a string like
$"foo bar" is potentially meant to be a message id even if foo is a
known variable.

Add a warning for the $"foo" case, but make it separate from the
existing warning so that projects that reuse variable names as their
message ids can separately disable the new warning.