### PR TITLE
Issue 1724 Support builtins in variable flow checks

### DIFF
--- a/src/ShellCheck/Analytics.hs
+++ b/src/ShellCheck/Analytics.hs
@@ -2129,6 +2129,7 @@ prop_checkUnused43= verifyTree checkUnusedAssignments "DEFINE_string foo '' ''"
 prop_checkUnused44= verifyNotTree checkUnusedAssignments "DEFINE_string \"foo$ibar\" x y"
 prop_checkUnused45= verifyTree checkUnusedAssignments "readonly foo=bar"
 prop_checkUnused46= verifyTree checkUnusedAssignments "readonly foo=(bar)"
+prop_checkUnused47= verifyNotTree checkUnusedAssignments "foo=1; builtin echo \"$foo\""
 checkUnusedAssignments params t = execWriter (mapM_ warnFor unused)
   where
     flow = variableFlow params
@@ -2189,6 +2190,7 @@ prop_checkUnassignedReferences35= verifyNotTree checkUnassignedReferences "echo 
 prop_checkUnassignedReferences36= verifyNotTree checkUnassignedReferences "read -a foo -r <<<\"foo bar\"; echo \"$foo\""
 prop_checkUnassignedReferences37= verifyNotTree checkUnassignedReferences "var=howdy; printf -v 'array[0]' %s \"$var\"; printf %s \"${array[0]}\";"
 prop_checkUnassignedReferences38= verifyTree (checkUnassignedReferences' True) "echo $VAR"
+prop_checkUnassignedReferences39= verifyNotTree checkUnassignedReferences "builtin read -r foo; echo \"$foo\""
 
 checkUnassignedReferences = checkUnassignedReferences' False
 checkUnassignedReferences' includeGlobals params t = warnings

--- a/src/ShellCheck/AnalyzerLib.hs
+++ b/src/ShellCheck/AnalyzerLib.hs
@@ -567,9 +567,12 @@ getReferencedVariableCommand _ = []
 --   VariableName :: String,   -- The variable name, i.e. foo
 --   VariableValue :: DataType -- A description of the value being assigned, i.e. "Literal string with value foo"
 -- )
-getModifiedVariableCommand base@(T_SimpleCommand _ _ (T_NormalWord _ (T_Literal _ x:_):rest)) =
+getModifiedVariableCommand base@(T_SimpleCommand i t (T_NormalWord _ (T_Literal _ x:_):rest)) =
    filter (\(_,_,s,_) -> not ("-" `isPrefixOf` s)) $
     case x of
+        "builtin" ->
+            getModifiedVariableCommand $ T_SimpleCommand i t rest
+
         "read" ->
             let params = map getLiteral rest
                 readArrayVars = getReadArrayVariables rest


### PR DESCRIPTION
https://github.com/koalaman/shellcheck/issues/1724

Add a pass through for `builtin cmd` to `cmd` for variable
assignment checks. Add test cases

Build!
```
/m/w/s/shellcheck (issue_1724_builtin_variable_flow=)> stack build
/m/w/s/shellcheck (issue_1724_builtin_variable_flow=)> echo $status
0
```

Test!
```
/m/w/s/shellcheck (issue_1724_builtin_variable_flow=)> stack test
...
=== prop_readScript5 from src/ShellCheck/Parser.hs:3103 ===
+++ OK, passed 1 test.

ShellCheck-0.7.0: Test suite test-shellcheck passed
/m/w/s/shellcheck (issue_1724_builtin_variable_flow=)> echo $status
0
```