### PR TITLE
Issue 1759 mapfile and process substition

### DIFF
--- a/src/ShellCheck/Analytics.hs
+++ b/src/ShellCheck/Analytics.hs
@@ -2190,6 +2190,7 @@ prop_checkUnassignedReferences36= verifyNotTree checkUnassignedReferences "read 
 prop_checkUnassignedReferences37= verifyNotTree checkUnassignedReferences "var=howdy; printf -v 'array[0]' %s \"$var\"; printf %s \"${array[0]}\";"
 prop_checkUnassignedReferences38= verifyTree (checkUnassignedReferences' True) "echo $VAR"
 prop_checkUnassignedReferences39= verifyNotTree checkUnassignedReferences "builtin export var=4; echo $var"
+prop_checkUnassignedReferences40= verifyNotTree checkUnassignedReferences "mapfile -t files <(cat); echo \"${files[@]}\""
 
 checkUnassignedReferences = checkUnassignedReferences' False
 checkUnassignedReferences' includeGlobals params t = warnings

--- a/src/ShellCheck/AnalyzerLib.hs
+++ b/src/ShellCheck/AnalyzerLib.hs
@@ -670,12 +670,16 @@ getModifiedVariableCommand base@(T_SimpleCommand id cmdPrefix (T_NormalWord _ (T
 
     -- mapfile has some curious syntax allowing flags plus 0..n variable names
     -- where only the first non-option one is used if any. Here we cheat and
-    -- just get the last one, if it's a variable name.
+    -- just get the last one, if it's a variable name, and omitting process
+    -- substitions.
     getMapfileArray base arguments = do
-        lastArg <- listToMaybe (reverse arguments)
+        lastArg <- listToMaybe (filter notProcSub $ reverse arguments)
         name <- getLiteralString lastArg
         guard $ isVariableName name
         return (base, lastArg, name, DataArray SourceExternal)
+
+    notProcSub (T_NormalWord _ (T_ProcSub{} :_)) = False
+    notProcSub _ = True
 
     -- get all the array variables used in read, e.g. read -a arr
     getReadArrayVariables args =


### PR DESCRIPTION
https://github.com/koalaman/shellcheck/issues/1759

When a simple process substition is used, this tripped up
the getMapfileArray function by making the last argument
not a variable

Build!
```
~/w/s/shellcheck (issue_1759_mapfile_proc_substition=)> stack build
~/w/s/shellcheck (issue_1759_mapfile_proc_substition=)> echo $status
0
```
Test!
```
~/w/s/shellcheck (issue_1759_mapfile_proc_substition=)> stack test
...
=== prop_readScript5 from src/ShellCheck/Parser.hs:3105 ===
+++ OK, passed 1 test.

ShellCheck-0.7.0: Test suite test-shellcheck passed
Completed 2 action(s).
I leaf@alder ~/w/s/shellcheck (issue_1759_mapfile_proc_substition=)> echo $status
0
```