### PR TITLE
Add support for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit
+    rev: v2.1.1
+    hooks:
+    -   id: validate_manifest
+
+-   repo: local
+    hooks:
+    -   id: shellcheck
+        name: shellcheck
+        language: docker_image
+        entry: koalaman/shellcheck:stable
+        types: [shell]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+# See https://pre-commit.com for more information
+-   id: shellcheck
+    name: shellcheck shell scripts
+    description: Validate shell scripts with shellcheck running in Docker
+    language: docker_image
+    entry: koalaman/shellcheck:v0.7.1
+    types: [shell]

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,17 @@ before_install: |
   test "$TRAVIS_BRANCH" = master && TAGS="$TAGS latest" || true
   test -n "$TRAVIS_TAG"          && TAGS="$TAGS stable $TRAVIS_TAG" || true
   echo "Tags are $TAGS"
+  set -e
+  # The version encoded in pre-commit and built version must be in sync. If not,
+  # the pre-commit version was forgotten to be updated.
+  if [ -n "$TRAVIS_TAG" ]; then
+    precommit_tag="$(awk -F: '/^ *entry:/ {print $NF}' .pre-commit-hooks.yaml)"
+    if [ "$TRAVIS_TAG" != "$precommit_tag" ]; then
+      echo "Wrong version number $precommit_tag in .pre-commit-hooks.yaml"
+      sleep 1  # give Travis time to grab the error message
+      exit 1
+    fi
+  fi
 
 # This is in global context and runs for every stage that doesn't override it.
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,27 @@ jobs:
         - source ./.multi_arch_docker
         - set -ex; multi_arch_docker::main; set +x
 
+    # Run pre-commit checks with the shellcheck docker package that was just
+    # deployed.
+    - stage: Pre-commit checks
+      language: python
+      python: 3.7
+      cache:
+        - pip
+        - directories: $HOME/.cache/pre-commit
+      install: pip install pre-commit
+      script: |
+        # Run pre-commit. It also uses shellcheck on itself from the just built
+        # and deployed docker image.
+        # Use the first build tag, or if there isn't any use 'latest'.
+        set -e
+        tag="$(echo "${TAGS/ */}")"
+        tag="${tag:-latest}"
+        echo "tag: $tag"
+        sed -i.bak -e "s/\(shellcheck\):.*/\1:$tag/" .pre-commit-config.yaml
+        pre-commit run --all-files --show-diff-on-failure --color=always
+        mv .pre-commit-config.yaml.bak .pre-commit-config.yaml
+
 # This is in global context and runs for every stage that doesn't override it.
 before_install: |
   DOCKER_BASE="$DOCKER_USERNAME/shellcheck"

--- a/README.md
+++ b/README.md
@@ -211,6 +211,13 @@ docker run --rm -v "$PWD:/mnt" koalaman/shellcheck:stable myscript
 
 or use `koalaman/shellcheck-alpine` if you want a larger Alpine Linux based image to extend. It works exactly like a regular Alpine image, but has shellcheck preinstalled.
 
+From [pre-commit](https://pre-commit.com/), add this to your `.pre-commit-config.yaml`:
+
+    -   repo: https://github.com/koalaman/shellcheck
+        rev: ''  # Use the sha / tag you want to point at
+        hooks:
+        -   id: shellcheck
+
 Using the [nix package manager](https://nixos.org/nix):
 ```sh
 nix-env -iA nixpkgs.shellcheck


### PR DESCRIPTION
[pre-commit](https://pre-commit.com/) is infrastructure to easily set up running any set of tools as git pre-commits on a repo. A tool only needs to provide a hook description (.pre-commit-hook.yaml) in its repo to become usable by the pre-commit infrastructure.

Here I'm adding this hook description, which makes shellcheck easily usable by pre-commit (see added example in README.md). I'm also turning pre-commit loose on this repo and configure it to run automatically on the Github Actions CI pipeline on every push and pull request.