### PR TITLE
Fix OSX build on Travis

### DIFF
--- a/.compile_binaries
+++ b/.compile_binaries
@@ -59,8 +59,8 @@ build_osx() {
   # Darwin x86_64 executable
   brew update
   brew install cabal-install pandoc gnu-tar
-  sudo ln -s /usr/local/bin/gsha512sum /usr/local/bin/sha512sum
-  sudo ln -s /usr/local/bin/gtar /usr/local/bin/tar
+  sudo ln -sf /usr/local/bin/gsha512sum /usr/local/bin/sha512sum
+  sudo ln -sf /usr/local/bin/gtar /usr/local/bin/tar
   export PATH="/usr/local/bin:$PATH"
 
   cabal update


### PR DESCRIPTION
Symlink was failing due to pre-existing target file:

    sudo ln -s /usr/local/bin/gsha512sum /usr/local/bin/sha512sum
    ln: /usr/local/bin/sha512sum: File exists

Build is passing now https://travis-ci.org/ArturKlauser/shellcheck/builds/630262030