### PR TITLE
README.md: Fix pre-compiled binary URL for aarch64

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Alternatively, you can download pre-compiled binaries for the latest release her
 
 * [Linux, x86_64](https://storage.googleapis.com/shellcheck/shellcheck-stable.linux.x86_64.tar.xz) (statically linked)
 * [Linux, armv6hf](https://storage.googleapis.com/shellcheck/shellcheck-stable.linux.armv6hf.tar.xz), i.e. Raspberry Pi (statically linked)
-* [Linux, aarch64](https://storage.googleapis.com/shellcheck/shellcheck-stable.linux.armv6hf.tar.xz) aka ARM64 (statically linked)
+* [Linux, aarch64](https://storage.googleapis.com/shellcheck/shellcheck-stable.linux.aarch64.tar.xz) aka ARM64 (statically linked)
 * [MacOS, x86_64](https://shellcheck.storage.googleapis.com/shellcheck-stable.darwin.x86_64.tar.xz)
 * [Windows, x86](https://storage.googleapis.com/shellcheck/shellcheck-stable.zip)
 


### PR DESCRIPTION
Pre-compiled binary URL for aarch64 was linked to armv6hf.