### PR TITLE
Add conda install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,10 @@ Or Windows (via [scoop](http://scoop.sh)):
 C:\> scoop install shellcheck
 ```
 
+From [conda-forge](https://anaconda.org/conda-forge/shellcheck):
+
+    conda install -c conda-forge shellcheck
+
 From Snap Store:
 
     snap install --channel=edge shellcheck


### PR DESCRIPTION
This adds installation instructions for anaconda users. The fact that `shellcheck` is [available on anaconda](https://anaconda.org/conda-forge/shellcheck) is very, very useful for users that work on remote servers / compute clusters without administrative privileges.