### PR TITLE
recognize `: ${parameter=word}` as assignment

### DIFF
--- a/src/ShellCheck/Analytics.hs
+++ b/src/ShellCheck/Analytics.hs
@@ -2205,6 +2205,7 @@ prop_checkUnassignedReferences36= verifyNotTree checkUnassignedReferences "read 
 prop_checkUnassignedReferences37= verifyNotTree checkUnassignedReferences "var=howdy; printf -v 'array[0]' %s \"$var\"; printf %s \"${array[0]}\";"
 prop_checkUnassignedReferences38= verifyTree (checkUnassignedReferences' True) "echo $VAR"
 prop_checkUnassignedReferences39= verifyNotTree checkUnassignedReferences "builtin export var=4; echo $var"
+prop_checkUnassignedReferences40= verifyNotTree checkUnassignedReferences ": ${foo=bar}"
 
 checkUnassignedReferences = checkUnassignedReferences' False
 checkUnassignedReferences' includeGlobals params t = warnings

--- a/src/ShellCheck/AnalyzerLib.hs
+++ b/src/ShellCheck/AnalyzerLib.hs
@@ -508,7 +508,7 @@ getModifiedVariables t =
         T_DollarBraced _ _ l -> maybeToList $ do
             let string = bracedString t
             let modifier = getBracedModifier string
-            guard $ ":=" `isPrefixOf` modifier
+            guard $ any (`isPrefixOf` modifier) ["=", ":="]
             return (t, t, getBracedReference string, DataString $ SourceFrom [l])
 
         t@(T_FdRedirect _ ('{':var) op) -> -- {foo}>&2 modifies foo


### PR DESCRIPTION
This fixes #1758 and adds a test for it.

for reference, commit 4fc48998037fd52c07c29b62cf25584ba738cead introduced the `:=` variant, and 3c5c74ff047ba99451b3a1a7689f5c1b84d1634b adds (broken) support for both variants (but misses this place). 