### PR TITLE
Mark that base >= 4.8.0.0 is required

### DIFF
--- a/ShellCheck.cabal
+++ b/ShellCheck.cabal
@@ -45,9 +45,7 @@ library
     build-depends:
       aeson,
       array,
-      -- GHC 7.6.3 (base 4.6.0.1) is buggy (#1131, #1119) in optimized mode.
-      -- Just disable that version entirely to fail fast.
-      base > 4.6.0.1 && < 5,
+      base >= 4.8.0.0 && < 5,
       bytestring,
       containers >= 0.5,
       deepseq >= 1.4.0.0,


### PR DESCRIPTION
We've actually already required base >= 4.8.0.0 since commit a8376a0 (in which we first used `<$>` without an import, which wasn't in the Prelude prior to this version). Since then, we've also made use of other more substantial features that de-facto require base >= 4.8.0.0 since they require GHC 7.10, such as `DeriveAnyClass`.