### PR TITLE
Don't try to deploy docker images on PR runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ jobs:
       os: osx
 
     - stage: Deploy docker image
-      if: branch = master
+      # Deploy only for pushes to master branch, not other branches, not PRs.
+      if: branch = master AND type = push
       script:
         - source ./.multi_arch_docker
         - set -ex; multi_arch_docker::main; set +x


### PR DESCRIPTION
For security reasons, PR runs don't have access to Travis secrets. However,
Docker deployment depends on the secret DOCKER_PASSWORD. Thus we shouldn't try
Docker deployment when running PRs since it will fail for lack of access.

This fixes #1884 