### PR TITLE
Revert "Use fromRight instead of reimplementing it"

### DIFF
--- a/src/ShellCheck/Formatter/GCC.hs
+++ b/src/ShellCheck/Formatter/GCC.hs
@@ -22,7 +22,6 @@ module ShellCheck.Formatter.GCC (format) where
 import ShellCheck.Interface
 import ShellCheck.Formatter.Format
 
-import Data.Either
 import Data.List
 import GHC.Exts
 import System.IO
@@ -45,7 +44,7 @@ outputAll cr sys = mapM_ f groups
     f group = do
         let filename = sourceFile (head group)
         result <- (siReadFile sys) filename
-        let contents = fromRight "" result
+        let contents = either (const "") id result
         outputResult filename contents group
 
 outputResult filename contents warnings = do

--- a/src/ShellCheck/Formatter/JSON1.hs
+++ b/src/ShellCheck/Formatter/JSON1.hs
@@ -24,7 +24,6 @@ import ShellCheck.Interface
 import ShellCheck.Formatter.Format
 
 import Data.Aeson
-import Data.Either
 import Data.IORef
 import Data.Monoid
 import GHC.Exts
@@ -119,7 +118,7 @@ collectResult ref cr sys = mapM_ f groups
     f group = do
         let filename = sourceFile (head group)
         result <- siReadFile sys filename
-        let contents = fromRight "" result
+        let contents = either (const "") id result
         let comments' = makeNonVirtual comments contents
         modifyIORef ref (\x -> comments' ++ x)
 

--- a/src/ShellCheck/Formatter/TTY.hs
+++ b/src/ShellCheck/Formatter/TTY.hs
@@ -25,7 +25,6 @@ import ShellCheck.Formatter.Format
 
 import Control.Monad
 import Data.Array
-import Data.Either
 import Data.Foldable
 import Data.Ord
 import Data.IORef
@@ -123,7 +122,7 @@ outputResult options ref result sys = do
 outputForFile color sys comments = do
     let fileName = sourceFile (head comments)
     result <- (siReadFile sys) fileName
-    let contents = fromRight "" result
+    let contents = either (const "") id result
     let fileLinesList = lines contents
     let lineCount = length fileLinesList
     let fileLines = listArray (1, lineCount) fileLinesList


### PR DESCRIPTION
We still support GHC 8.0, which didn't have fromRight.

This reverts commit 64c31d91422e3c48cc7ed0176b069fa11456cee8.