### PR TITLE
update dependency free AUR package

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ On Arch Linux based distros:
 
     pacman -S shellcheck
 
-or get the dependency free [shellcheck-static](https://aur.archlinux.org/packages/shellcheck-static/) from the AUR.
+or get the dependency free [shellcheck-bin](https://aur.archlinux.org/packages/shellcheck-bin/) from the AUR.
 
 On Gentoo based distros:
 


### PR DESCRIPTION
The `shellcheck-static` AUR package has been removed and `shellcheck-bin` is an option for a dependency free AUR package.