### PR TITLE
Fix snap distribution unable to process scripts in Unicode(Chinese) (fixes #1643)

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -31,6 +31,8 @@ apps:
   shellcheck:
     command: usr/bin/shellcheck
     plugs: [home, removable-media]
+    environment:
+      LANG: C.UTF-8
 
 parts:
   shellcheck:


### PR DESCRIPTION
The snap runtime only ships the C.UTF-8 locale, as other locales don't seem to be used just hardcode it for now.

Signed-off-by: 林博仁(Buo-ren, Lin) <Buo.Ren.Lin@gmail.com>