### PR TITLE
Add MacPorts as installation option in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,10 @@ On macOS (OS X) with Homebrew:
 
     brew install shellcheck
 
+Or with MacPorts:
+
+    sudo port install shellcheck
+
 On OpenBSD:
 
     pkg_add shellcheck


### PR DESCRIPTION
Thought it was worth mentioning MacPorts as an installation option on macOS.