### PR TITLE
Whitelist podman for SC2016 about '$var'

### DIFF
--- a/src/ShellCheck/Analytics.hs
+++ b/src/ShellCheck/Analytics.hs
@@ -1015,6 +1015,7 @@ checkSingleQuotedVariables params t@(T_SingleQuoted id s) =
                 ,"alias"
                 ,"sudo" -- covering "sudo sh" and such
                 ,"docker" -- like above
+                ,"podman"
                 ,"dpkg-query"
                 ,"jq"  -- could also check that user provides --arg
                 ,"rename"


### PR DESCRIPTION
Same as 08d2eef4111afde4 but for podman.

Fixes https://github.com/koalaman/shellcheck/issues/2057