### PR TITLE
Error on backslash in comment

### DIFF
--- a/src/ShellCheck/Parser.hs
+++ b/src/ShellCheck/Parser.hs
@@ -1039,9 +1039,14 @@ readComment = do
     unexpecting "shellcheck annotation" readAnnotationPrefix
     readAnyComment
 
+prop_readAnyComment = isOk readAnyComment "# Comment"
+prop_readAnyComment1 = not $ isOk readAnyComment "# Comment \\\n"
 readAnyComment = do
     char '#'
-    many $ noneOf "\r\n"
+    comment <- many $ noneOf "\\\r\n"
+    bs <- many $ oneOf "\\"
+    unless (null bs) (fail "Backslash in or directly after comment")
+    return comment
 
 prop_readNormalWord = isOk readNormalWord "'foo'\"bar\"{1..3}baz$(lol)"
 prop_readNormalWord2 = isOk readNormalWord "foo**(foo)!!!(@@(bar))"


### PR DESCRIPTION
- Report error in case of a backspace in a comment

Backspaces in comments are no good. In most cases they are the result of
commenting out a longer line, that was broken down. This usually results
in the shell treating the following lines as their own commands on their
own lines instead of as parts of the longer, broken down line.

There are counter examples, but their usage of the backslash to break the line is rather academic anyways.

The following will result in an error:
```
echo "bla 1" \
  #&& echo "bla 2" \
  && echo "bla 3"
```
The following would be the output for the example above:
```
In backslash.sh line 2:
echo "bla 1" \
^-- SC1073: Couldn't parse this simple command. Fix to allow more checks.


In backslash.sh line 3:
  #&& echo "bla 2" \
                    ^-- SC1072: Backslash in or directly after comment. Fix any mentioned problems and try again.
```

The following would be a (rather academic) example of a false positive:
```
echo "bla 1"; \
  #echo "bla 2"; \
  echo "bla 3";
```

I would prefer to emit a warning and continue in this case, but as far as my very limited understanding of the code goes, the parser can only fail completely or be completely silent. Since all tokens in a comment are consumed by the parser, but then discarded, I see no way to achieve that. Also for some reason, I think this throw the numbering for the `SC1XXX` errors off.
Especially after reading https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html part 2.2.1, I don't think erroring out is the way to go. Maybe you have more insight on this, @koalaman ?

related to #2132