### PR TITLE
suppress ntlm error messages in Windows build

### DIFF
--- a/build/windows.x86_64/Dockerfile
+++ b/build/windows.x86_64/Dockerfile
@@ -5,7 +5,7 @@ ENV TARGETNAME windows.x86_64
 # We don't need wine32, even though it complains
 USER root
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && apt-get install -y curl busybox wine
+RUN apt-get update && apt-get install -y curl busybox wine winbind
 
 # Fetch Windows version, will be available under z:\haskell
 WORKDIR /haskell


### PR DESCRIPTION
when building for windows there are many error message like below

```
003a:err:winediag:SECUR32_initNTLMSP ntlm_auth was not found or is outdated. Make sure that ntlm_auth >= 3.0.25 is in your path. Usually, you can find it in the winbind package of your distribution.
```