### PR TITLE
Enable publishing to ghcr.io (Github container registry)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,6 +121,7 @@ jobs:
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          GITHUB_GHCR_TOKEN: ${{ secrets.GITHUB_GHCR_TOKEN }}
           DOCKER_EMAIL: ${{ secrets.DOCKER_EMAIL }}
           DOCKER_BASE: ${{ secrets.DOCKER_USERNAME }}/shellcheck
         run: |

--- a/.multi_arch_docker
+++ b/.multi_arch_docker
@@ -36,6 +36,11 @@ function multi_arch_docker::login_to_docker_hub() {
   echo "$DOCKER_PASSWORD" | docker login -u="$DOCKER_USERNAME" --password-stdin
 }
 
+# Log in to Github container registry for deployment.
+function multi_arch_docker::login_to_github_container_registry() {
+  echo "$GITHUB_GHCR_TOKEN" | docker login -u="$DOCKER_USERNAME" --password-stdin
+}
+
 # Run buildx build and push. Passed in arguments augment the command line.
 function multi_arch_docker::buildx() {
   mkdir -p /tmp/empty
@@ -51,10 +56,13 @@ function multi_arch_docker::buildx() {
 
 # Build and push plain and alpine docker images for all tags.
 function multi_arch_docker::build_and_push_all() {
+  declare -a registries=("" "ghcr.io/")
   for tag in $TAGS; do
-    multi_arch_docker::buildx -t "$DOCKER_BASE:$tag" --build-arg "tag=$tag"
-    multi_arch_docker::buildx -t "$DOCKER_BASE-alpine:$tag" \
-      --build-arg "tag=$tag" --target alpine
+    for registry in "${registries[@]}"; do
+      multi_arch_docker::buildx -t "${registry}$DOCKER_BASE:$tag" --build-arg "tag=$tag"
+      multi_arch_docker::buildx -t "${registry}$DOCKER_BASE-alpine:$tag" \
+        --build-arg "tag=$tag" --target alpine
+    done
   done
 }
 
@@ -101,6 +109,7 @@ function multi_arch_docker::main() {
 
   multi_arch_docker::install_docker_buildx
   multi_arch_docker::login_to_docker_hub
+  multi_arch_docker::login_to_github_container_registry
   multi_arch_docker::build_and_push_all
   multi_arch_docker::test_all
 }

--- a/README.md
+++ b/README.md
@@ -210,10 +210,11 @@ From Snap Store:
 
     snap install --channel=edge shellcheck
 
-From Docker Hub:
+From Docker Hub / GitHub Container Registry:
 
 ```sh
 docker run --rm -v "$PWD:/mnt" koalaman/shellcheck:stable myscript
+docker run --rm -v "$PWD:/mnt" ghcr.io/koalaman/shellcheck:stable myscript
 # Or :v0.4.7 for that version, or :latest for daily builds
 ```
 


### PR DESCRIPTION
Dockerhub got unfortunately rate limited regarding pulling containers.

By publishing to the Github container registry (can be found here https://github.com/koalaman?tab=packages) that rate limit can be avoided and makes pipelines using shellcheck via Docker more reliable.

Merging this requires adding a token called GITHUB_GHCR_TOKEN (with the capability to push containers) to the repo secrets.