### PR TITLE
add check for set e and operator

### DIFF
--- a/src/ShellCheck/Analytics.hs
+++ b/src/ShellCheck/Analytics.hs
@@ -190,6 +190,7 @@ nodeChecks = [
     ,checkDollarQuoteParen
     ,checkUselessBang
     ,checkTranslatedStringVariable
+    ,checkPipelineE
     ,checkModifiedArithmeticInRedirection
     ,checkBlatantRecursion
     ,checkBadTestAndOr
@@ -3807,6 +3808,12 @@ checkUselessBang params t = when (hasSetE params) $ mapM_ check (getNonReturning
             [_] -> []
             x:rest -> x : dropLast rest
             _ -> []
+
+prop_checkPipelineE1 = verify checkPipelineE "set -e; echo hi && echo hello"
+prop_checkPipelineE2 = verifyNot checkPipelineE "echo hi && echo hello"
+checkPipelineE params x@(T_AndIf id _ _) = when (hasSetE params) $
+    info id 3061 "&& operators running with -e set will not exit on error"
+checkPipelineE _ _ = return ()
 
 prop_checkModifiedArithmeticInRedirection1 = verify checkModifiedArithmeticInRedirection "ls > $((i++))"
 prop_checkModifiedArithmeticInRedirection2 = verify checkModifiedArithmeticInRedirection "cat < \"foo$((i++)).txt\""


### PR DESCRIPTION
Add a new rule to check for `&&` usage with `set -e` set.

Recently I got burned by https://unix.stackexchange.com/questions/312631/bash-script-with-set-e-doesnt-stop-on-command/318412#318412

I'm pretty new to Haskell so I figured I'd start small. In the future, we could expand this to include `if`, `while`, `||`, etc.

While this rule is very broad-reaching, I believe it to be helpful.

Looking for advice on:
1. Is this a reasonable thing to `info` on?
2. What else is required to add a new rule (e.g. adding the wiki page)?
3. Is the implementation idiomatic haskell?


For some backstory on why this is useful:

I had a script like:
```
#!/bin/bash

set -e

(exit 1) && echo "hello"
exit_code="$?"
echo command exited "$exit_code"
```

This actually prints `command exited 1`, while I'd expect it to not even make it to the `echo`.

The following script does **not** make it to the echo:
```
#!/bin/bash

set -e

(exit 1)
exit_code="$?"
echo command exited "$exit_code"
```

To me this was extremely unintuitive and I wish shellcheck would have warned me.