### PR TITLE
Add a comma to function characters

### DIFF
--- a/src/ShellCheck/Parser.hs
+++ b/src/ShellCheck/Parser.hs
@@ -66,7 +66,7 @@ doubleQuote = char '"'
 variableStart = upper <|> lower <|> oneOf "_"
 variableChars = upper <|> lower <|> digit <|> oneOf "_"
 -- Chars to allow in function names
-functionChars = variableChars <|> oneOf ":+?-./^@"
+functionChars = variableChars <|> oneOf ":+?-./^@,"
 -- Chars to allow in functions using the 'function' keyword
 extendedFunctionChars = functionChars <|> oneOf "[]*=!"
 specialVariable = oneOf (concat specialVariables)


### PR DESCRIPTION
#### For bugs
- SC1036
- My shellcheck version 0.7.2 and "online"
- [x] The rule's wiki page does not already cover this (e.g. https://shellcheck.net/wiki/SC1036)
- [x] I tried on https://www.shellcheck.net/ and verified that this is still a problem on the latest commit

#### Here's a snippet or screenshot that shows the problem:

```sh
#!/bin/bash
f,unc() { echo hello world; }
f,unc
```

#### Here's what shellcheck currently says:

```
In /tmp/1.sh line 2:
f,unc() { echo hello world; }
     ^-- SC1036: '(' is invalid here. Did you forget to escape it?
     ^-- SC1088: Parsing stopped here. Invalid use of parentheses?

For more information:
  https://www.shellcheck.net/wiki/SC1036 -- '(' is invalid here. Did you forg...
  https://www.shellcheck.net/wiki/SC1088 -- Parsing stopped here. Invalid use...
```

#### Here's what I wanted or expected to see:

Nothing, code is valid. Bash has _very_ relaxed rules for function names and comma is also allowed in function names.