### PR TITLE
Problem: 'then' words in pcs scripts confuse ShellCheck

### DIFF
--- a/src/ShellCheck/Parser.hs
+++ b/src/ShellCheck/Parser.hs
@@ -1068,7 +1068,7 @@ prop_readNormalWord9 = isOk readSubshell "(foo\\ ;\nbar)"
 prop_readNormalWord10 = isWarning readNormalWord "\x201Chello\x201D"
 prop_readNormalWord11 = isWarning readNormalWord "\x2018hello\x2019"
 prop_readNormalWord12 = isWarning readNormalWord "hello\x2018"
-readNormalWord = readNormalishWord "" ["do", "done", "then", "fi", "esac"]
+readNormalWord = readNormalishWord "" ["do", "done", "fi", "esac"]
 
 readPatternWord = readNormalishWord "" ["esac"]
 


### PR DESCRIPTION
Pacemaker-related scripts often use 'then' word unquoted and it does
work in bash. Example:

```
pcs constraint order VirtualIP then dummy_resource kind=Optional
```

This instruction causes SC1010 warning which seems to be a
false-positive.

It seems like 'then' word itself is not a keyword in bash. I guess that
it is understood as a keyword only in context of `if` clause.

Solution:
Exclude 'then' from the list of terminal tokens in `readNormalWord`
function.

Closes #2266