### PR TITLE
Minor changes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ On systems with Stack (installs to `~/.local/bin`):
 
 On Debian based distros:
 
-    apt-get install shellcheck
+    sudo apt install shellcheck
 
 On Arch Linux based distros:
 
@@ -157,8 +157,8 @@ On Gentoo based distros:
 
 On EPEL based distros:
 
-    yum -y install epel-release
-    yum install ShellCheck
+    sudo yum -y install epel-release
+    sudo yum install ShellCheck
 
 On Fedora based distros:
 
@@ -166,7 +166,7 @@ On Fedora based distros:
 
 On FreeBSD:
 
-    pkg install hs-ShellCheck
+    sudo pkg install hs-ShellCheck
 
 On macOS (OS X) with Homebrew:
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ On Fedora based distros:
 
 On FreeBSD:
 
-    sudo pkg install hs-ShellCheck
+    pkg install hs-ShellCheck
 
 On macOS (OS X) with Homebrew:
 


### PR DESCRIPTION
It's a recommended practice to use apt instead `apt-get`:

> apt is a second command-line based front end provided by APT which overcomes some design mistakes of apt-get.

https://debian-handbook.info/browse/stable/sect.apt-get.html

Also added `sudo` for commands needed root privileges.