### PR TITLE
Do not suggest `grep -c` as a replacement for `grep -l/-L | wc -l`

### DIFF
--- a/src/ShellCheck/Analytics.hs
+++ b/src/ShellCheck/Analytics.hs
@@ -508,6 +508,8 @@ prop_checkPipePitfalls13 = verifyNot checkPipePitfalls "foo | grep bar | wc -c"
 prop_checkPipePitfalls14 = verifyNot checkPipePitfalls "foo | grep -o bar | wc -cmwL"
 prop_checkPipePitfalls15 = verifyNot checkPipePitfalls "foo | grep bar | wc -cmwL"
 prop_checkPipePitfalls16 = verifyNot checkPipePitfalls "foo | grep -r bar | wc -l"
+prop_checkPipePitfalls17 = verifyNot checkPipePitfalls "foo | grep -l bar | wc -l"
+prop_checkPipePitfalls18 = verifyNot checkPipePitfalls "foo | grep -L bar | wc -l"
 checkPipePitfalls _ (T_Pipeline id _ commands) = do
     for ["find", "xargs"] $
         \(find:xargs:_) ->
@@ -529,7 +531,9 @@ checkPipePitfalls _ (T_Pipeline id _ commands) = do
             let flagsGrep = maybe [] (map snd . getAllFlags) $ getCommand grep
                 flagsWc = maybe [] (map snd . getAllFlags) $ getCommand wc
             in
-                unless (any (`elem` ["o", "only-matching", "r", "R", "recursive"]) flagsGrep || any (`elem` ["m", "chars", "w", "words", "c", "bytes", "L", "max-line-length"]) flagsWc || null flagsWc) $
+                unless (any (`elem` ["l", "files-with-matches", "L", "files-without-matches", "o", "only-matching", "r", "R", "recursive"]) flagsGrep
+                        || any (`elem` ["m", "chars", "w", "words", "c", "bytes", "L", "max-line-length"]) flagsWc
+                        || null flagsWc) $
                     style (getId grep) 2126 "Consider using grep -c instead of grep|wc -l."
 
     didLs <- fmap or . sequence $ [


### PR DESCRIPTION
`grep -c` counts the number of matches, and `grep -l/-L` outputs the names of the files with/without matches. Now, if I want the number of files with/without matches, I would write something like this:
```sh
grep -li "fail" ./*.log | wc -l
```
However, Shellcheck suggests replacing the `grep -l/-L | wc -l` with `grep -c`, which is not the correct solution:
```
Line 3:
grep -li "fail" ./*.log | wc -l
^-- SC2126: Consider using grep -c instead of grep|wc -l.
```
Therefore, I have added `-l/-L` to the blacklist of `grep` options that prevent [SC2126](https://github.com/koalaman/shellcheck/wiki/SC2126) from being issued.