### PR TITLE
Add extra checks for masked return codes

### DIFF
--- a/src/ShellCheck/Checks/Commands.hs
+++ b/src/ShellCheck/Checks/Commands.hs
@@ -101,8 +101,6 @@ commandChecks = [
     ++ map checkArgComparison declaringCommands
     ++ map checkMaskedReturns declaringCommands
 
-declaringCommands = ["local", "declare", "export", "readonly", "typeset", "let"]
-
 
 optionalChecks = map fst optionalCommandChecks
 optionalCommandChecks :: [(CheckDescription, CommandCheck)]

--- a/src/ShellCheck/Data.hs
+++ b/src/ShellCheck/Data.hs
@@ -138,3 +138,5 @@ shellForExecutable name =
         _ -> Nothing
 
 flagsForRead = "sreu:n:N:i:p:a:t:"
+
+declaringCommands = ["local", "declare", "export", "readonly", "typeset", "let"]


### PR DESCRIPTION
Adds the check mentioned here, plus related ones: https://github.com/koalaman/shellcheck/pull/2303#discussion_r698056295 Example:

`/tmp/a.sh`:

```bash
#!/usr/bin/env bash
set -e
readarray -t files < <(ls)
echo "${files[@]}"
```

```
% ./quickrun /tmp/a.sh --enable=check-extra-masked-returns
Up to date

In /tmp/a.sh line 3:
readarray -t files < <(ls)
                       ^-- SC2312: Consider invoking this command separately to avoid masking its return value (or use '|| true' to ignore).

For more information:
  https://www.shellcheck.net/wiki/SC2312 -- Consider invoking this command se...

```