### PR TITLE
Allow specifying color= in shellcheckrc (closes #2350)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Git (0.8.0)
 ### Added
+- `color=` directive can be added to .shellceckrc
 - `disable=all` now conveniently disables all warnings
 - `external-sources=true` directive can be added to .shellcheckrc to make
   shellcheck behave as if `-x` was specified.

--- a/shellcheck.1.md
+++ b/shellcheck.1.md
@@ -41,7 +41,10 @@ not warn at all, as `ksh` supports decimals in arithmetic contexts.
 
 :   For TTY output, enable colors *always*, *never* or *auto*. The default
     is *auto*. **--color** without an argument is equivalent to
-    **--color=always**.
+    **--color=auto**.
+
+    This option may also be enabled using `color=` in
+    `.shellcheckrc`. This flag takes precedence.
 
 **-i**\ *CODE1*[,*CODE2*...],\ **--include=***CODE1*[,*CODE2*...]
 
@@ -232,6 +235,10 @@ Here a shell brace group is used to suppress a warning on multiple lines:
 
 Valid keys are:
 
+**color**
+:   Set to `auto`, `never` or `always` in `.shellcheckrc` to automatically
+    detect, never or always use color output with the `tty` output format.
+
 **disable**
 :   Disables a comma separated list of error codes for the following command.
     The command can be a simple command like `echo foo`, or a compound command
@@ -276,6 +283,9 @@ Unless `--norc` is used, ShellCheck will look for a file `.shellcheckrc` or
 it will read `key=value` pairs from it and treat them as file-wide directives.
 
 Here is an example `.shellcheckrc`:
+
+    # Always force color output on the tty output
+    color=always
 
     # Look for 'source'd files relative to the checked script,
     # and also look for absolute paths in /mnt/chroot

--- a/src/ShellCheck/Parser.hs
+++ b/src/ShellCheck/Parser.hs
@@ -1005,6 +1005,14 @@ readAnnotationWithoutPrefix sandboxed = do
         key <- many1 (letter <|> char '-')
         char '=' <|> fail "Expected '=' after directive key"
         annotations <- case key of
+            "color" -> do
+             color <- many1 $ noneOf " \n"
+             option <- parseColorOption color
+             return options {
+                 formatterOptions = (formatterOptions options) {
+                     foColorOption = option
+                 }
+             }
             "disable" -> readElement `sepBy` char ','
               where
                 readElement = readRange <|> readAll


### PR DESCRIPTION
To be able to set the color option in the config file (detection in GitLab CI fails for example) is useful when using template shellcheck containers for one. Secondly, storing config in the repo is also a thing :)

Sadly, I got a bit overconfident and got lost very quickly. I never seen haskell before so there's a learning curve required I suppose. I did make a start hopefully for whomever can pick it up :)