### PR TITLE
Fix issue 2450 ipv6 SC2102  warning

### DIFF
--- a/src/ShellCheck/Analytics.hs
+++ b/src/ShellCheck/Analytics.hs
@@ -2703,7 +2703,7 @@ checkCharRangeGlob p t@(T_Glob id str) |
         && contents /= ":"
     then warn id 2101 "Named class needs outer [], e.g. [[:digit:]]."
     else
-        when ('[' `notElem` contents && hasDupes) $
+        when ('[' `notElem` contents && ':' `notElem` contents && hasDupes) $
             info id 2102 "Ranges can only match single chars (mentioned due to duplicates)."
   where
     isCharClass str = "[" `isPrefixOf` str && "]" `isSuffixOf` str


### PR DESCRIPTION
This is attempt to fix issue 2450 here: 

https://github.com/koalaman/shellcheck/issues/2450

## Test

Test script:

```
$ cat test.sh
#!/bin/bash
curl -k https://[2620:10d:c0a8:2b::127]/
```

Before:

```
$ which shellcheck
/Users/gengwg/.cabal/bin/shellcheck

$ shellcheck -V
ShellCheck - shell script analysis tool
version: 0.8.0
license: GNU General Public License, version 3
website: https://www.shellcheck.net

$ shellcheck test.sh

In test.sh line 2:
curl -k https://[2620:10d:c0a8:2b::127]/
                ^---------------------^ SC2102 (info): Ranges can only match single chars (mentioned due to duplicates).

For more information:
  https://www.shellcheck.net/wiki/SC2102 -- Ranges can only match single char...
```

After:

Test:

```
$ cabal test
Resolving dependencies...
Build profile: -w ghc-8.10.7 -O1
In order, the following will be built (use -v for more details):
 - ShellCheck-0.8.0 (lib) (first run)
 - ShellCheck-0.8.0 (test:test-shellcheck) (first run)
Configuring library for ShellCheck-0.8.0..
Preprocessing library for ShellCheck-0.8.0..
Building library for ShellCheck-0.8.0..
....
[1 of 1] Compiling Main             ( test/shellcheck.hs, /Users/gengwg/github/shellcheck/dist-newstyle/build/x86_64-osx/ghc-8.10.7/ShellCheck-0.8.0/t/test-shellcheck/build/test-shellcheck/test-shellcheck-tmp/Main.o )
Linking /Users/gengwg/github/shellcheck/dist-newstyle/build/x86_64-osx/ghc-8.10.7/ShellCheck-0.8.0/t/test-shellcheck/build/test-shellcheck/test-shellcheck ...
Running 1 test suites...
Test suite test-shellcheck: RUNNING...
Test suite test-shellcheck: PASS
Test suite logged to:
/Users/gengwg/github/shellcheck/dist-newstyle/build/x86_64-osx/ghc-8.10.7/ShellCheck-0.8.0/t/test-shellcheck/test/ShellCheck-0.8.0-test-shellcheck.log
1 of 1 test suites (1 of 1 test cases) passed.
```

```
$ cabal install --overwrite-policy=always
Wrote tarball sdist to
/Users/gengwg/shellcheck/dist-newstyle/sdist/ShellCheck-0.8.0.tar.gz
Resolving dependencies...
Up to date
Symlinking 'shellcheck' to '/Users/gengwg/.cabal/bin/shellcheck'
```

Check again:

```
$ shellcheck ~/test.sh
<no output now>
```