### PR TITLE
Permit colon after exec

### DIFF
--- a/src/ShellCheck/Analytics.hs
+++ b/src/ShellCheck/Analytics.hs
@@ -1876,6 +1876,7 @@ prop_checkSpuriousExec7 = verifyNot checkSpuriousExec "exec file; echo failed; e
 prop_checkSpuriousExec8 = verifyNot checkSpuriousExec "exec {origout}>&1- >tmp.log 2>&1; bar"
 prop_checkSpuriousExec9 = verify checkSpuriousExec "for file in rc.d/*; do exec \"$file\"; done"
 prop_checkSpuriousExec10 = verifyNot checkSpuriousExec "exec file; r=$?; printf >&2 'failed\n'; return $r"
+prop_checkSpuriousExec11 = verifyNot checkSpuriousExec "exec file; :"
 checkSpuriousExec _ = doLists
   where
     doLists (T_Script _ _ cmds) = doList cmds False
@@ -1891,7 +1892,7 @@ checkSpuriousExec _ = doLists
 
     stripCleanup = reverse . dropWhile cleanup . reverse
     cleanup (T_Pipeline _ _ [cmd]) =
-        isCommandMatch cmd (`elem` ["echo", "exit", "printf", "return"])
+        isCommandMatch cmd (`elem` [":", "echo", "exit", "printf", "return"])
         || isAssignment cmd
     cleanup _ = False
 


### PR DESCRIPTION
ShellCheck throws warning SC2093 when a script contains commands that could never be executed because they are after an `exec`.  Command `:` does nothing, so add it to the list of commands that don’t trigger this warning.