### PR TITLE
Fix 7 shellcheck issues and enable Trunk for optional use

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2

--- a/.prepare_deploy
+++ b/.prepare_deploy
@@ -35,13 +35,13 @@ do
 
   for dir in windows.*/
   do
-    ( cd "$dir" && zip "../shellcheck-$tag.zip" * )
+    ( cd "$dir" && zip "../shellcheck-$tag.zip" ./* )
   done
 
   for dir in {linux,darwin}.*/
   do
     base="${dir%/}"
-    ( cd "$dir" && tar -cJf "../shellcheck-$tag.$base.tar.xz" --transform="s:^:shellcheck-$tag/:" * )
+    ( cd "$dir" && tar -cJf "../shellcheck-$tag.$base.tar.xz" --transform="s:^:shellcheck-$tag/:" ./* )
   done
 done
 

--- a/.trunk/.gitignore
+++ b/.trunk/.gitignore
@@ -1,0 +1,7 @@
+*out
+*logs
+*actions
+*notifications
+plugins
+user_trunk.yaml
+user.yaml

--- a/.trunk/config/.markdownlint.yaml
+++ b/.trunk/config/.markdownlint.yaml
@@ -1,0 +1,10 @@
+# Autoformatter friendly markdownlint config (all formatting rules disabled)
+default: true
+blank_lines: false
+bullet: false
+html: false
+indentation: false
+line_length: false
+spaces: false
+url: false
+whitespace: false

--- a/.trunk/config/.shellcheckrc
+++ b/.trunk/config/.shellcheckrc
@@ -1,0 +1,2 @@
+enable=all
+source-path=SCRIPTDIR

--- a/.trunk/config/svgo.config.js
+++ b/.trunk/config/svgo.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  plugins: [
+    {
+      name: "preset-default",
+      params: {
+        overrides: {
+          removeViewBox: false, // https://github.com/svg/svgo/issues/1128
+          sortAttrs: true,
+          removeOffCanvasPaths: true,
+        },
+      },
+    },
+  ],
+};

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,0 +1,23 @@
+version: 0.1
+cli:
+  version: 1.0.1
+plugins:
+  sources:
+    - id: trunk
+      ref: v0.0.5
+      uri: https://github.com/trunk-io/plugins
+lint:
+  enabled:
+    - markdownlint@0.32.2
+    - hadolint@2.10.0
+    - git-diff-check
+    - shfmt@3.5.0
+    - svgo@3.0.0
+    - shellcheck@0.8.0
+    - actionlint@1.6.22
+    - prettier@2.7.1
+    - gitleaks@8.15.0
+runtimes:
+  enabled:
+    - go@1.18.3
+    - node@16.14.2

--- a/build/darwin.x86_64/build
+++ b/build/darwin.x86_64/build
@@ -5,6 +5,7 @@ set -xe
   chmod +x striptests && ./striptests
   mkdir "$TARGETNAME"
   cabal update
+  # shellcheck disable=SC2086 # Intended splitting of CABALOPTS
   ( IFS=';'; cabal build $CABALOPTS )
   find . -name shellcheck -type f -exec mv {} "$TARGETNAME/" \;
   ls -l "$TARGETNAME"

--- a/build/linux.aarch64/build
+++ b/build/linux.aarch64/build
@@ -5,6 +5,7 @@ set -xe
   chmod +x striptests && ./striptests
   mkdir "$TARGETNAME"
   cabal update
+  # shellcheck disable=SC2086 # Intended splitting of CABALOPTS
   ( IFS=';'; cabal build $CABALOPTS --enable-executable-static )
   find . -name shellcheck -type f -exec mv {} "$TARGETNAME/" \;
   ls -l "$TARGETNAME"

--- a/build/linux.armv6hf/build
+++ b/build/linux.armv6hf/build
@@ -6,6 +6,7 @@ cd /scratch
   chmod +x striptests && ./striptests
   mkdir "$TARGETNAME"
   # This script does not cabal update because compiling anything new is slow
+  # shellcheck disable=SC2086 # Intended splitting of CABALOPTS
   ( IFS=';'; cabal build $CABALOPTS --enable-executable-static )
   find . -name shellcheck -type f -exec mv {} "$TARGETNAME/" \;
   ls -l "$TARGETNAME"

--- a/build/linux.x86_64/build
+++ b/build/linux.x86_64/build
@@ -5,6 +5,7 @@ set -xe
   chmod +x striptests && ./striptests
   mkdir "$TARGETNAME"
   cabal update
+  # shellcheck disable=SC2086 # Intended splitting of CABALOPTS
   ( IFS=';'; cabal build $CABALOPTS --enable-executable-static )
   find . -name shellcheck -type f -exec mv {} "$TARGETNAME/" \;
   ls -l "$TARGETNAME"

--- a/build/windows.x86_64/build
+++ b/build/windows.x86_64/build
@@ -9,6 +9,7 @@ set -xe
   chmod +x striptests && ./striptests
   mkdir "$TARGETNAME"
   cabal update
+  # shellcheck disable=SC2086 # Intended splitting of CABALOPTS
   ( IFS=';'; cabal build $CABALOPTS )
   find dist*/ -name shellcheck.exe -type f -ls -exec mv {} "$TARGETNAME/" \;
   ls -l "$TARGETNAME"


### PR DESCRIPTION
Hey there! I'm David, an engineer and founder of [trunk.io](https://docs.trunk.io/docs). Part of my pull request to your project enables the option for Trunk to be used by your contributors, if they so choose. Trunk is completely free for open-source projects, so I'm not trying to sell you anything. These configuration files won't be used by anything unless a contributor has trunk installed locally or is using the [trunk vscode extension](https://marketplace.visualstudio.com/items?itemName=trunk.io). Just trying to help your other contributors to be able to get their formatting, linting, static analysis, etc out of the way before the code actually gets committed and merged into shellcheck.

This trunk config turns on [9 linters & formatters](https://github.com/koalaman/shellcheck/pull/2618/files#diff-45a5a35dd7ad9a52d0fd3540f6c0d16a763575de51cc9a0a6c6f6a9f1da62ecd), including shellcheck itself, which are all applicable to the files/technologies used in the repo. It runs shellcheck based on either the shebang _or_ the file extension, which is how I noticed that there were 7 existing spellcheck issues in the shellcheck repo, in extension-less files 😉

Trunk also has a [GitHub Action](https://github.com/trunk-io/trunk-action) which could be run to ensure no new issues slip into the repo. With these 7 issues fixed, there are [169 issues left in the codebase](https://app.warp.dev/block/yIOqK6OS1iti34Gjh3C8ZO). Feel free to let me know if there are any questions 🙂 