### PR TITLE
Warn when using deprecated rgrep

### DIFF
--- a/src/ShellCheck/Analytics.hs
+++ b/src/ShellCheck/Analytics.hs
@@ -3029,7 +3029,7 @@ checkShouldUseGrepQ params t =
             T_DollarExpansion _ [x] -> getPipeline x
             T_Pipeline _ _ cmds -> return cmds
             _ -> fail "unknown"
-    isGrep = (`elem` ["grep", "egrep", "fgrep", "zgrep"])
+    isGrep = (`elem` ["grep", "egrep", "fgrep", "rgrep", "zgrep"])
 
 prop_checkTestArgumentSplitting1 = verify checkTestArgumentSplitting "[ -e *.mp3 ]"
 prop_checkTestArgumentSplitting2 = verifyNot checkTestArgumentSplitting "[[ $a == *b* ]]"

--- a/src/ShellCheck/Checks/Commands.hs
+++ b/src/ShellCheck/Checks/Commands.hs
@@ -91,6 +91,7 @@ commandChecks = [
     ,checkDeprecatedTempfile
     ,checkDeprecatedEgrep
     ,checkDeprecatedFgrep
+    ,checkDeprecatedRgrep
     ,checkWhileGetoptsCase
     ,checkCatastrophicRm
     ,checkLetUsage
@@ -987,6 +988,10 @@ checkDeprecatedEgrep = CommandCheck (Basename "egrep") $
 prop_checkDeprecatedFgrep = verify checkDeprecatedFgrep "fgrep '*' files"
 checkDeprecatedFgrep = CommandCheck (Basename "fgrep") $
     \t -> info (getId $ getCommandTokenOrThis t) 2197 "fgrep is non-standard and deprecated. Use grep -F instead."
+
+prop_checkDeprecatedRgrep = verify checkDeprecatedRgrep "rgrep '*' dir"
+checkDeprecatedRgrep = CommandCheck (Basename "rgrep") $
+    \t -> info (getId $ getCommandTokenOrThis t) 2324 "rgrep is non-standard and deprecated. Use grep -r instead."
 
 prop_checkWhileGetoptsCase1 = verify checkWhileGetoptsCase "while getopts 'a:b' x; do case $x in a) foo;; esac; done"
 prop_checkWhileGetoptsCase2 = verify checkWhileGetoptsCase "while getopts 'a:' x; do case $x in a) foo;; b) bar;; esac; done"


### PR DESCRIPTION
Just as `egrep` and `fgrep` have been deprecated by both the POSIX and GNU versions of grep, Debian has deprecated the `rgrep` command it injects into the GNU grep package they distribute. (Which Ubuntu inherits, as well.)

The patches applied by Debian now [list all three as deprecated][manpatch] (though all three are also listed as "Debian-specific", so perhaps `egrep` and `fgrep` have already been removed upstream?), even though it also [removes the deprecation warning][warnpatch] from `egrep` and `fgrep` (`rgrep` never had one).

This PR adds a new rule, SC2324, which is identical to [SC2196][sc2196] and [SC2197][sc2197] save that it targets `rgrep`. As a bonus, `rgrep` has also been added to the list of greps for which `-q` should be suggested ([SC2143][sc2143]).

It probably also makes sense to add all three variants to [SC2126][sc2126] (piping grep to `wc -l` when `grep -c` could be used instead), but I didn't discover that until I was typing up this description and my (fairly limited) Haskell skills aren't up to doing it quickly. 😅 If others agree that it should be done though, I'll happily make the change when I have more time in the next few days.

[manpatch]: https://salsa.debian.org/debian/grep/-/blob/debian/master/debian/patches/02-man_egrep_fgrep_rgrep.patch
[warnpatch]: https://salsa.debian.org/debian/grep/-/blob/debian/master/debian/patches/01-disable-egrep-fgrep-warnings.patch
[sc2126]: https://www.shellcheck.net/wiki/SC2126
[sc2143]: https://www.shellcheck.net/wiki/SC2143
[sc2196]: https://www.shellcheck.net/wiki/SC2196
[sc2197]: https://www.shellcheck.net/wiki/SC2197