### PR TITLE
Document Trunk Check integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Services and platforms that have ShellCheck pre-installed and ready to use:
 * [Code Factor](https://www.codefactor.io/)
 * [CircleCI](https://circleci.com) via the [ShellCheck Orb](https://circleci.com/orbs/registry/orb/circleci/shellcheck)
 * [Github](https://github.com/features/actions) (only Linux)
+* [Trunk Check](https://trunk.io/products/check) (universal linter; [allows you to explicitly version your shellcheck install](https://github.com/trunk-io/plugins/blob/bcbb361dcdbe4619af51ea7db474d7fb87540d20/.trunk/trunk.yaml#L32)) via the [shellcheck plugin](https://github.com/trunk-io/plugins/blob/main/linters/shellcheck/plugin.yaml)
 
 Most other services, including [GitLab](https://about.gitlab.com/), let you install
 ShellCheck yourself, either through the system's package manager (see [Installing](#installing)),


### PR DESCRIPTION
Trunk Check is a universal linter which integrates with a wide variety of linters and formatters, `shellcheck` included.

We're big fans of `shellcheck` and figured that you might find our tool to be interesting enough to include it in the integrations list.

---

We did previously reach out in #2618 and came off a little strong - wanted to say sorry again about that; it wasn't necessarily in the best taste.