### PR TITLE
Darwin arm64 builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
     needs: package_source
     strategy:
       matrix:
-        build: [linux.x86_64, linux.aarch64, linux.armv6hf, darwin.x86_64, windows.x86_64]
+        build: [linux.x86_64, linux.aarch64, linux.armv6hf, darwin.x86_64, darwin.aarch64, windows.x86_64]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ Alternatively, you can download pre-compiled binaries for the latest release her
 * [Linux, armv6hf](https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.armv6hf.tar.xz), i.e. Raspberry Pi (statically linked)
 * [Linux, aarch64](https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.aarch64.tar.xz) aka ARM64 (statically linked)
 * [macOS, x86_64](https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.darwin.x86_64.tar.xz)
+* [macOS, aarch64](https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.darwin.aarch64.tar.xz)
 * [Windows, x86](https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.zip)
 
 or see the [GitHub Releases](https://github.com/koalaman/shellcheck/releases) for other releases
@@ -548,4 +549,3 @@ Happy ShellChecking!
 
 * The wiki has [long form descriptions](https://github.com/koalaman/shellcheck/wiki/Checks) for each warning, e.g. [SC2221](https://github.com/koalaman/shellcheck/wiki/SC2221).
 * ShellCheck does not attempt to enforce any kind of formatting or indenting style, so also check out [shfmt](https://github.com/mvdan/sh)!
-

--- a/build/darwin.aarch64/Dockerfile
+++ b/build/darwin.aarch64/Dockerfile
@@ -1,0 +1,33 @@
+FROM liushuyu/osxcross@sha256:fa32af4677e2860a1c5950bc8c360f309e2a87e2ddfed27b642fddf7a6093b76
+
+ENV TARGET aarch64-apple-darwin18
+ENV TARGETNAME darwin.aarch64
+
+# Build dependencies
+USER root
+ENV DEBIAN_FRONTEND noninteractive
+RUN sed -e 's/focal/kinetic/g' -i /etc/apt/sources.list
+RUN apt-get update
+RUN apt-get dist-upgrade -y
+RUN apt-get install -y ghc automake autoconf llvm curl alex happy
+
+# Build GHC
+WORKDIR /ghc
+RUN curl -L "https://downloads.haskell.org/~ghc/9.2.5/ghc-9.2.5-src.tar.xz" | tar xJ --strip-components=1
+RUN ./configure --host x86_64-linux-gnu --build x86_64-linux-gnu --target "$TARGET"
+RUN cp mk/flavours/quick-cross.mk mk/build.mk && make -j "$(nproc)"
+RUN make install
+RUN curl -L "https://downloads.haskell.org/~cabal/cabal-install-3.9.0.0/cabal-install-3.9-x86_64-linux-alpine.tar.xz" | tar xJv -C /usr/local/bin
+
+# Due to an apparent cabal bug, we specify our options directly to cabal
+# It won't reuse caches if ghc-options are specified in ~/.cabal/config
+ENV CABALOPTS "--with-ghc=$TARGET-ghc;--with-hc-pkg=$TARGET-ghc-pkg"
+
+# Prebuild the dependencies
+RUN cabal update && IFS=';' && cabal install --dependencies-only $CABALOPTS ShellCheck
+
+# Copy the build script
+COPY build /usr/bin
+
+WORKDIR /scratch
+ENTRYPOINT ["/usr/bin/build"]

--- a/build/darwin.aarch64/build
+++ b/build/darwin.aarch64/build
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -xe
+{
+  tar xzv --strip-components=1
+  chmod +x striptests && ./striptests
+  mkdir "$TARGETNAME"
+  cabal update
+  ( IFS=';'; cabal build $CABALOPTS )
+  find . -name shellcheck -type f -exec mv {} "$TARGETNAME/" \;
+  ls -l "$TARGETNAME"
+  "$TARGET-strip" -Sx "$TARGETNAME/shellcheck"
+  ls -l "$TARGETNAME"
+} >&2
+tar czv "$TARGETNAME"

--- a/build/darwin.aarch64/tag
+++ b/build/darwin.aarch64/tag
@@ -1,0 +1,1 @@
+koalaman/scbuilder-darwin-aarch64


### PR DESCRIPTION
Refs #2714 

Hi, I would like to propose an addition to the build process to add binaries for Apple Silicon CPUs.
I am not familiar with Haskell's toolchain, so I tried to follow the other builds.
As of my branch, the build fails as it can't find the `koalaman/scbuilder-darwin-aarch64` docker image: I tried to build it myself but it fails due to `ar` not being found, see:

```
#12 74.74 checking for a working context diff... diff -U 1
#12 74.78 checking for a BSD-compatible install... /usr/bin/install -c
#12 74.91 checking for aarch64-apple-darwin18-ar... no
#12 74.91 configure: error: cannot find ar in your PATH, no idea how to make a library
```

Perhaps someone's open to collaborating on this one?