### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Dependabot is a tool that helps to keep dependencies up to date by automatically creating pull requests whenever a new version of a dependency can be merged without breaking changes.

This PR adds ` dependabot.yml` which configures version updates for GitHub Actions and the directory points to `.github/workflows`

A maintainer might have to additionally enable Dependabot by going to `settings` -> `Code security and analysis` and enable these 3 buttons

![image](https://github.com/koalaman/shellcheck/assets/56389521/b600cb0f-a560-44c5-a89a-5c2c3ece1a9c)

