### PR TITLE
improve short description for SC2038

### DIFF
--- a/src/ShellCheck/Analytics.hs
+++ b/src/ShellCheck/Analytics.hs
@@ -562,7 +562,7 @@ checkPipePitfalls _ (T_Pipeline id _ commands) = do
                 hasParameter "print0",
                 hasParameter "printf"
               ]) $ warn (getId find) 2038
-                      "Use -print0/-0 or -exec + to allow for non-alphanumeric filenames."
+                      "Use 'find .. -print0 | xargs -0 ..' or 'find .. -exec .. +' to allow non-alphanumeric filenames."
 
     for ["ps", "grep"] $
         \(ps:grep:_) ->


### PR DESCRIPTION
* The short description used to say that until commit aac7d76047a5b28d064b17a5d0fac022054d05a0 from 2014. It appears that it was changed by mistake in that commit to something less readable.

* With the message "use -print0/-0" we were confused and introduced a bug in our code because we didn't understand what to do with the "-0".

* SC2011 (source https://github.com/koalaman/shellcheck/blob/c9e27c24700cdc5b84cfca1f7a90fe07f542867c/src/ShellCheck/Analytics.hs#L591) uses that exact warning message, we copied it from there.

cc: @swalchemist