### PR TITLE
Drop root privileges in Docker container

### DIFF
--- a/Dockerfile.multi-arch
+++ b/Dockerfile.multi-arch
@@ -23,4 +23,8 @@ FROM scratch
 LABEL maintainer="Vidar Holen <vidar@vidarholen.net>"
 WORKDIR /mnt
 COPY --from=alpine /bin/shellcheck /bin/
+
+# Drop root privileges.
+USER 65535:65535
+
 ENTRYPOINT ["/bin/shellcheck"]


### PR DESCRIPTION
By default, Docker runs containers with root privileges (!).  This isn't necessary for shellcheck.  This PR causes the container to be run as an unprivileged user instead.

FYI, the highest possible UID and GID (65535) must be used in this patch since the final scratch image does not include /etc/passwd, /etc/group, nor the support code to resolve names to UIDs/GIDs.