### PR TITLE
Fix: extend []-related bashism checks on `test` calls too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 - SC2324: Warn when x+=1 appends instead of increments
 - SC2325: Warn about multiple `!`s in dash/sh.
 - SC2326: Warn about `foo | ! bar` in bash/dash/sh.
+- SC3012: Warn about lexicographic-compare bashism in test like in [ ]
+- SC3013: Warn bashism `test _ -op/-nt/-ef _` like in [ ]
+- SC3014: Warn bashism `test _ == _` like in [ ]
+- SC3015: Warn bashism `test _ =~ _` like in [ ]
+- SC3016: Warn bashism `test -v _` like in [ ]
+- SC3017: Warn bashism `test -a _` like in [ ]
 
 ### Fixed
 - source statements with here docs now work correctly


### PR DESCRIPTION
Hi @koalaman, @josephcsible :wave: 

Big fan of shellcheck, loving it, using regularly, evangelizing even as a linter that doesn't suck (~unlike pylint~), that is produces actually useful output. FWIW, good license choice too... respected.

So, I was scripting a thing today, something that should've worked both in zsh and bash, and stumbled on an issue. Perfect chance to give back by contributing!

[SC3014][] warns about `[ foo == bar ]` being a bashism, not posix-compatible. However, it doesn't catch `test foo == bar`.

This little patch fixes that, and also exactly similar bashism checks SC3012–3017. 

I'm also adding tests.

Please review. Not sure this is the best way to fix it — there's fair bit of duplication, also `ViewPatterns` might not be to everyone's taste (though I like it).

[SC3014]: https://github.com/koalaman/shellcheck/wiki/SC3014