### PR TITLE
Testsuite: report which module failed the tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ cabal.config
 /parts/
 /prime/
 *.snap
+/dist-newstyle/

--- a/test/shellcheck.hs
+++ b/test/shellcheck.hs
@@ -18,21 +18,24 @@ import qualified ShellCheck.Parser
 
 main = do
     putStrLn "Running ShellCheck tests..."
-    results <- sequence [
-        ShellCheck.Analytics.runTests
-        ,ShellCheck.AnalyzerLib.runTests
-        ,ShellCheck.ASTLib.runTests
-        ,ShellCheck.CFG.runTests
-        ,ShellCheck.CFGAnalysis.runTests
-        ,ShellCheck.Checker.runTests
-        ,ShellCheck.Checks.Commands.runTests
-        ,ShellCheck.Checks.ControlFlow.runTests
-        ,ShellCheck.Checks.Custom.runTests
-        ,ShellCheck.Checks.ShellSupport.runTests
-        ,ShellCheck.Fixer.runTests
-        ,ShellCheck.Formatter.Diff.runTests
-        ,ShellCheck.Parser.runTests
+    failures <- filter (not . snd) <$> mapM sequenceA tests
+    if null failures then exitSuccess else do
+      putStrLn "Tests failed for the following module(s):"
+      mapM (putStrLn . ("- ShellCheck." ++) . fst) failures
+      exitFailure
+  where
+    tests =
+      [ ("Analytics"          , ShellCheck.Analytics.runTests)
+      , ("AnalyzerLib"        , ShellCheck.AnalyzerLib.runTests)
+      , ("ASTLib"             , ShellCheck.ASTLib.runTests)
+      , ("CFG"                , ShellCheck.CFG.runTests)
+      , ("CFGAnalysis"        , ShellCheck.CFGAnalysis.runTests)
+      , ("Checker"            , ShellCheck.Checker.runTests)
+      , ("Checks.Commands"    , ShellCheck.Checks.Commands.runTests)
+      , ("Checks.ControlFlow" , ShellCheck.Checks.ControlFlow.runTests)
+      , ("Checks.Custom"      , ShellCheck.Checks.Custom.runTests)
+      , ("Checks.ShellSupport", ShellCheck.Checks.ShellSupport.runTests)
+      , ("Fixer"              , ShellCheck.Fixer.runTests)
+      , ("Formatter.Diff"     , ShellCheck.Formatter.Diff.runTests)
+      , ("Parser"             , ShellCheck.Parser.runTests)
       ]
-    if and results
-      then exitSuccess
-      else exitFailure


### PR DESCRIPTION
This also fixes the problem that the testsuite threw `exitFailure`
even when it succeeded (which I found inexplicable).

Once this is published, the testsuite could be enabled in Stackage again.
