### PR TITLE
Replace Atom reference with Pulsar Edit equivalent

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ You can see ShellCheck suggestions directly in a variety of editors.
 
 * Sublime, through [SublimeLinter](https://github.com/SublimeLinter/SublimeLinter-shellcheck).
 
-* Atom, through [Linter](https://github.com/AtomLinter/linter-shellcheck).
+* Pulsar Edit (former Atom), through [linter-shellcheck-pulsar](https://github.com/pulsar-cooperative/linter-shellcheck-pulsar).
 
 * VSCode, through [vscode-shellcheck](https://github.com/timonwong/vscode-shellcheck).
 


### PR DESCRIPTION
Since Microsoft acquired GitHub and discontinued Atom in 2022, the community started a fork at https://pulsar-edit.dev/. Linking to an archived repository under the Atom organization does not make sense anymore, so link to active Pulsar fork instead.

The Pulsar Edit history is explained at length in https://optimizedbyotto.com/post/pulsar-best-text-file-and-code-editor/.