### PR TITLE
Implement rcfile option

### DIFF
--- a/shellcheck.1.md
+++ b/shellcheck.1.md
@@ -71,6 +71,11 @@ not warn at all, as `ksh` supports decimals in arithmetic contexts.
 
 :   Don't try to look for .shellcheckrc configuration files.
 
+--rcfile\ RCFILE
+
+:   Prefer the specified configuration file over searching for one
+    in the default locations.
+
 **-o**\ *NAME1*[,*NAME2*...],\ **--enable=***NAME1*[,*NAME2*...]
 
 :   Enable optional checks. The special name *all* enables all of them.

--- a/shellcheck.hs
+++ b/shellcheck.hs
@@ -76,7 +76,8 @@ data Options = Options {
     externalSources  :: Bool,
     sourcePaths      :: [FilePath],
     formatterOptions :: FormatterOptions,
-    minSeverity      :: Severity
+    minSeverity      :: Severity,
+    rcfile           :: FilePath
 }
 
 defaultOptions = Options {
@@ -86,7 +87,8 @@ defaultOptions = Options {
     formatterOptions = newFormatterOptions {
         foColorOption = ColorAuto
     },
-    minSeverity = StyleC
+    minSeverity = StyleC,
+    rcfile = []
 }
 
 usageHeader = "Usage: shellcheck [OPTIONS...] FILES..."
@@ -107,6 +109,9 @@ options = [
         (NoArg $ Flag "list-optional" "true") "List checks disabled by default",
     Option "" ["norc"]
         (NoArg $ Flag "norc" "true") "Don't look for .shellcheckrc files",
+    Option "" ["rcfile"]
+        (ReqArg (Flag "rcfile") "RCFILE")
+        "Prefer the specified configuration file over searching for one",
     Option "o" ["enable"]
         (ReqArg (Flag "enable") "check1,check2..")
         "List of optional checks to enable (or 'all')",
@@ -367,6 +372,11 @@ parseOption flag options =
                 }
             }
 
+        Flag "rcfile" str -> do
+            return options {
+                rcfile = str 
+            }
+
         Flag "enable" value ->
             let cs = checkSpec options in return options {
                 checkSpec = cs {
@@ -441,18 +451,23 @@ ioInterface options files = do
         fallback :: FilePath -> IOException -> IO FilePath
         fallback path _ = return path
 
+
     -- Returns the name and contents of .shellcheckrc for the given file
     getConfig cache filename = do
-        path <- normalize filename
-        let dir = takeDirectory path
-        (previousPath, result) <- readIORef cache
-        if dir == previousPath
-          then return result
-          else do
-            paths <- getConfigPaths dir
-            result <- findConfig paths
-            writeIORef cache (dir, result)
-            return result
+        contents <- readConfig (rcfile options)
+        if isNothing contents
+          then do
+            path <- normalize filename
+            let dir = takeDirectory path
+            (previousPath, result) <- readIORef cache
+            if dir == previousPath
+              then return result
+              else do
+                paths <- getConfigPaths dir
+                result <- findConfig paths
+                writeIORef cache (dir, result)
+                return result
+          else return contents
 
     findConfig paths =
         case paths of


### PR DESCRIPTION
This introduces the "--rcfile" argument which allows a specific shellcheckrc file to be passed.
If specified and the given file exists, the default locations will not be searched and the specified file will be used.