### PR TITLE
Recommend `typeset` instead of `declare` in SC2324

### DIFF
--- a/src/ShellCheck/Analytics.hs
+++ b/src/ShellCheck/Analytics.hs
@@ -5017,7 +5017,8 @@ checkPlusEqualsNumber params t =
             state <- CF.getIncomingState cfga id
             guard $ isNumber state word
             guard . not $ fromMaybe False $ CF.variableMayBeDeclaredInteger state var
-            return $ warn id 2324 "var+=1 will append, not increment. Use (( var += 1 )), declare -i var, or quote number to silence."
+            -- Recommend "typeset" because ksh does not have "declare".
+            return $ warn id 2324 "var+=1 will append, not increment. Use (( var += 1 )), typeset -i var, or quote number to silence."
         _ -> return ()
 
   where


### PR DESCRIPTION
Bash has both `typeset` and `declare`, but ksh has `typeset` only. Recommend the more portable alternative to users.