### PR TITLE
Fix builders for Linux

### DIFF
--- a/build/linux.aarch64/Dockerfile
+++ b/build/linux.aarch64/Dockerfile
@@ -12,11 +12,15 @@ RUN apt-get update && apt-get install -y llvm gcc-$TARGET
 
 # The rest are from 22.10
 RUN sed -e 's/focal/kinetic/g' -i /etc/apt/sources.list
+# Kinetic does not receive updates anymore, switch to last available
+RUN sed -e 's/archive.ubuntu.com/old-releases.ubuntu.com/g' -i /etc/apt/sources.list
+RUN sed -e 's/security.ubuntu.com/old-releases.ubuntu.com/g' -i /etc/apt/sources.list
+
 RUN apt-get update && apt-get install -y ghc alex happy automake autoconf build-essential curl qemu-user-static
 
 # Build GHC
 WORKDIR /ghc
-RUN curl -L "https://downloads.haskell.org/~ghc/9.2.5/ghc-9.2.5-src.tar.xz" | tar xJ --strip-components=1
+RUN curl -L "https://downloads.haskell.org/~ghc/9.2.8/ghc-9.2.8-src.tar.xz" | tar xJ --strip-components=1
 RUN ./boot && ./configure --host x86_64-linux-gnu --build x86_64-linux-gnu --target "$TARGET"
 RUN cp mk/flavours/quick-cross.mk mk/build.mk && make -j "$(nproc)"
 RUN make install

--- a/build/linux.x86_64/Dockerfile
+++ b/build/linux.x86_64/Dockerfile
@@ -1,4 +1,8 @@
-FROM alpine:latest
+FROM alpine:3.16
+# alpine:3.16 (GHC 9.0.1):  5.8 megabytes
+# alpine:3.17 (GHC 9.0.2): 15.0 megabytes
+# alpine:3.18 (GHC 9.4.4): 29.0 megabytes
+# alpine:3.19 (GHC 9.4.7): 29.0 megabytes
 
 ENV TARGETNAME linux.x86_64
 


### PR DESCRIPTION
This reduces the size of the Linux x86_64 binary from 15 megabytes to 5.8 megabytes and fixes the build for Linux aarch64.

Building with `alpine:latest` creates a binary of 29 megabytes, but when building with `alpine:3.16` it's just 5.8 megabytes. I'm not sure, though, what piece of GHC, GCC/LLVM, etc. is causing the increased size.
The published build of ShellCheck 0.10.0 is 15 megabytes, instead of the expected 29 megabyes using the builder of this repo. Perhaps the container was still cached and based on an older version of `alpine`?

Attempting to build for Linux aarch64 failed with this message. Ubuntu Kinetic is not provided with updates anmore.
I'm not sure why the Linux binary for aarch64 is so much larger than for x86_64 (31 megabytes), but it's probably nothing I can fix. The Linux aarch64 binary of ShellCheck 0.9.0 is about 20.5 megabytes.

```text
Step 8/19 : RUN apt-get update && apt-get install -y ghc alex happy automake autoconf build-essential curl qemu-user-static
 ---> Running in 435bd345ec51
Ign:1 http://archive.ubuntu.com/ubuntu kinetic InRelease
Ign:2 http://archive.ubuntu.com/ubuntu kinetic-updates InRelease
Ign:3 http://archive.ubuntu.com/ubuntu kinetic-backports InRelease
Err:4 http://archive.ubuntu.com/ubuntu kinetic Release
  404  Not Found [IP: 185.125.190.36 80]
Err:5 http://archive.ubuntu.com/ubuntu kinetic-updates Release
  404  Not Found [IP: 185.125.190.36 80]
Err:6 http://archive.ubuntu.com/ubuntu kinetic-backports Release
  404  Not Found [IP: 185.125.190.36 80]
Ign:7 http://security.ubuntu.com/ubuntu kinetic-security InRelease
Err:8 http://security.ubuntu.com/ubuntu kinetic-security Release
  404  Not Found [IP: 91.189.91.83 80]
Reading package lists...
E: The repository 'http://archive.ubuntu.com/ubuntu kinetic Release' does not have a Release file.
E: The repository 'http://archive.ubuntu.com/ubuntu kinetic-updates Release' does not have a Release file.
E: The repository 'http://archive.ubuntu.com/ubuntu kinetic-backports Release' does not have a Release file.
E: The repository 'http://security.ubuntu.com/ubuntu kinetic-security Release' does not have a Release file.
```