### PR TITLE
Add new bats variables stderr and stderr_lines

### DIFF
--- a/src/ShellCheck/AnalyzerLib.hs
+++ b/src/ShellCheck/AnalyzerLib.hs
@@ -535,7 +535,9 @@ getModifiedVariables t =
         T_BatsTest {} -> [
             (t, t, "lines", DataArray SourceExternal),
             (t, t, "status", DataString SourceInteger),
-            (t, t, "output", DataString SourceExternal)
+            (t, t, "output", DataString SourceExternal),
+            (t, t, "stderr", DataString SourceExternal),
+            (t, t, "stderr_lines", DataArray SourceExternal)
             ]
 
         -- Count [[ -v foo ]] as an "assignment".


### PR DESCRIPTION
These are being set by `run --separate-stderr` and have been introduced in https://github.com/bats-core/bats-core/releases/tag/v1.5.0