### PR TITLE
Add Flox to list of installation methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,11 @@ Using the [nix package manager](https://nixos.org/nix):
 nix-env -iA nixpkgs.shellcheck
 ```
 
+Using the [Flox package manager](https://flox.dev/)
+```sh
+flox install shellcheck
+```
+
 Alternatively, you can download pre-compiled binaries for the latest release here:
 
 * [Linux, x86_64](https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz) (statically linked)


### PR DESCRIPTION
`shellcheck` seems to be available and working inside [Flox] today!
Since Flox is related to Nix, I thought it'd make sense to add it to the list. 😁

[Flox]: https://flox.dev/docs/