### PR TITLE
Add a reason directive to aid in documenting annotations

### DIFF
--- a/src/ShellCheck/Parser.hs
+++ b/src/ShellCheck/Parser.hs
@@ -1083,6 +1083,10 @@ readAnnotationWithoutPrefix sandboxed = do
                         parseNoteAt pos ErrorC 1145 "Unknown external-sources value. Expected true/false."
                         return []
 
+            -- noop to allow a reason to be given for the annotation
+            "reason" -> do
+                return []
+
             _ -> do
                 parseNoteAt keyPos WarningC 1107 "This directive is unknown. It will be ignored."
                 anyChar `reluctantlyTill` whitespace


### PR DESCRIPTION
Fixes #3016

> [!NOTE]
> This is not yet tested locally, but I wanted to raise it to get any other feedback on the contribution.