### PR TITLE
Recognize "oksh" executable name as ksh

### DIFF
--- a/src/ShellCheck/Data.hs
+++ b/src/ShellCheck/Data.hs
@@ -167,6 +167,7 @@ shellForExecutable name =
         "ksh"   -> return Ksh
         "ksh88" -> return Ksh
         "ksh93" -> return Ksh
+        "oksh"  -> return Ksh
         _ -> Nothing
 
 flagsForRead = "sreu:n:N:i:p:a:t:"

--- a/src/ShellCheck/Parser.hs
+++ b/src/ShellCheck/Parser.hs
@@ -3387,7 +3387,8 @@ readScriptFile sourced = do
         "busybox sh",
         "bash",
         "bats",
-        "ksh"
+        "ksh",
+        "oksh"
         ]
     badShells = [
         "awk",


### PR DESCRIPTION
A portable version of OpenBSD's ksh is distributed with the executable name [oksh][1]. It's a descendant of pdksh and can be shellchecked as ksh.

[1]: https://github.com/ibara/oksh
