### PR TITLE
Added link to `shellcheck-scan` the GitHub Action  :handshake: 

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Services and platforms that have ShellCheck pre-installed and ready to use:
 * [Code Factor](https://www.codefactor.io/)
 * [Codety](https://www.codety.io/) via the [Codety Scanner](https://github.com/codetyio/codety-scanner)
 * [CircleCI](https://circleci.com) via the [ShellCheck Orb](https://circleci.com/orbs/registry/orb/circleci/shellcheck)
-* [Github](https://github.com/features/actions) (only Linux)
+* [Github](https://github.com/features/actions) (only Linux) via the [ShellCheck SARIF Analysis](https://github.com/marketplace/actions/shellcheck-sarif-analysis)
 * [Trunk Check](https://trunk.io/products/check) (universal linter; [allows you to explicitly version your shellcheck install](https://github.com/trunk-io/plugins/blob/bcbb361dcdbe4619af51ea7db474d7fb87540d20/.trunk/trunk.yaml#L32)) via the [shellcheck plugin](https://github.com/trunk-io/plugins/blob/main/linters/shellcheck/plugin.yaml)
 * [CodeRabbit](https://coderabbit.ai/)
 


### PR DESCRIPTION
# Update README.md

Added link to [ShellCheck SARIF Analysis](https://github.com/marketplace/actions/shellcheck-sarif-analysis) GitHub Action - A third-party OSS action that generates SARIF reports from ShellCheck analysis, enabling GitHub Advanced Security integration. Helps teams track shell script quality through GitHub's code scanning UI without additional configuration.

## Additional details:

  **Marketplace link**: [ShellCheck SARIF Analysis](https://github.com/marketplace/actions/shellcheck-sarif-analysis)
  **Release Notes**: [Latest Release Notes](https://github.com/reactive-firewall/shellcheck-scan/releases/latest)
  **Public Repository**: [shellcheck-scan](https://github.com/reactive-firewall/shellcheck-scan)

---

Contributor hereby **acknowledges**:

- [x] Contributions must be licensed under the GNU GPLv3.
    * The contributor retains the copyright.
