### PR TITLE
Recognize internal variables new in bash 5.3

### DIFF
--- a/src/ShellCheck/Data.hs
+++ b/src/ShellCheck/Data.hs
@@ -49,6 +49,7 @@ internalVariables = [
     "LINES", "MAIL", "MAILCHECK", "MAILPATH", "OPTERR", "PATH",
     "POSIXLY_CORRECT", "PROMPT_COMMAND", "PROMPT_DIRTRIM", "PS0", "PS1",
     "PS2", "PS3", "PS4", "SHELL", "TIMEFORMAT", "TMOUT", "TMPDIR",
+    "BASH_MONOSECONDS", "BASH_TRAPSIG", "GLOBSORT",
     "auto_resume", "histchars",
 
     -- Other
@@ -78,7 +79,7 @@ variablesWithoutSpaces = specialVariablesWithoutSpaces ++ [
     "EPOCHREALTIME", "EPOCHSECONDS", "LINENO", "OPTIND", "PPID", "RANDOM",
     "READLINE_ARGUMENT", "READLINE_MARK", "READLINE_POINT", "SECONDS",
     "SHELLOPTS", "SHLVL", "SRANDOM", "UID", "COLUMNS", "HISTFILESIZE",
-    "HISTSIZE", "LINES"
+    "HISTSIZE", "LINES", "BASH_MONOSECONDS", "BASH_TRAPSIG"
 
     -- shflags
     , "FLAGS_ERROR", "FLAGS_FALSE", "FLAGS_TRUE"


### PR DESCRIPTION
From the bug-bash@gnu.org announcement "[Bash-5.3-beta available](https://lists.gnu.org/archive/html/bug-bash/2024-12/msg00120.html)":

> q. GLOBSORT: new variable to specify how to sort the results of pathname expansion (name, size, blocks, mtime, atime, ctime, none) in ascending or descending order.
> 
> w. BASH_MONOSECONDS: new dynamic variable that returns the value of the system's monotonic clock, if one is available.
> 
> x. BASH_TRAPSIG: new variable, set to the numeric signal number of the trap being executed while it's running.