### PR TITLE
Add bang as a valid char for function names

### DIFF
--- a/src/ShellCheck/Parser.hs
+++ b/src/ShellCheck/Parser.hs
@@ -67,7 +67,7 @@ doubleQuote = char '"'
 variableStart = upper <|> lower <|> oneOf "_"
 variableChars = upper <|> lower <|> digit <|> oneOf "_"
 -- Chars to allow in function names
-functionChars = variableChars <|> oneOf ":+?-./^@,"
+functionChars = variableChars <|> oneOf "#:+?-./^@,"
 -- Chars to allow in functions using the 'function' keyword
 extendedFunctionChars = functionChars <|> oneOf "[]*=!"
 specialVariable = oneOf (concat specialVariables)


### PR DESCRIPTION
As described by issue #3102, the parser fails when a function name contains a pound symbol. As far as I can tell, it is a valid way of naming functions in bash, it works with the `function` keyword and without. Not sure how portable it is, but I can add a check for that as part of this PR if it's desirable by @koalaman 

The only thing I can find about function names in bash is here:
https://www.gnu.org/software/bash/manual/bash.html#Shell-Functions

It only explicitly forbids `$` in function names.

This closes #3102