### PR TITLE
Add optional check for whether a variable can be `readonly`

### DIFF
--- a/src/ShellCheck/Analytics.hs
+++ b/src/ShellCheck/Analytics.hs
@@ -71,7 +71,6 @@ treeChecks = [
     ,checkUseBeforeDefinition
     ,checkAliasUsedInSameParsingUnit
     ,checkArrayValueUsedAsIndex
-    ,checkVariableCanBeReadonly
     ]
 
 checker spec params = mkChecker spec params treeChecks
@@ -280,6 +279,13 @@ optionalTreeChecks = [
         cdPositive = "cat foo | grep bar",
         cdNegative = "grep bar foo"
     }, nodeChecksToTreeCheck [checkUuoc])
+
+    ,(newCheckDescription {
+        cdName = "check-variable-can-be-readonly",
+        cdDescription = "Check that a variable can be made readonly if it isn't assigned to.",
+        cdPositive = "x=3; echo $x",
+        cdNegative = "readonly x=3; echo $x"
+    }, checkVariableCanBeReadonly)
     ]
 
 optionalCheckMap :: Map.Map String (Parameters -> Token -> [TokenComment])

--- a/src/ShellCheck/Checker.hs
+++ b/src/ShellCheck/Checker.hs
@@ -359,7 +359,7 @@ prop_optionIncludes2 =
 
 prop_optionIncludes3 =
     -- expect 2086, no inclusions provided, so it is reported
-    [2086, 2331] == checkOptionIncludes Nothing "#!/bin/sh\n var='a b'\n echo $var"
+    [2086] == checkOptionIncludes Nothing "#!/bin/sh\n var='a b'\n echo $var"
 
 prop_optionIncludes4 =
     -- expect 2086 & 2154, only 2154 included, so only that's reported
@@ -398,6 +398,12 @@ prop_canEnableOptionalsWithRc = result == [2244]
   where
     result = checkWithRc "enable=avoid-nullary-conditions" emptyCheckSpec {
         csScript = "#!/bin/sh\n[ \"$1\" ]"
+    }
+
+prop_canEnableCheckForReadonlyVariables = result == [2331]
+  where
+    result = checkWithRc "enable=check-variable-can-be-readonly" emptyCheckSpec {
+        csScript = "#!/bin/sh\na=3\necho \"$a\""
     }
 
 prop_sourcePathRedirectsName = result == [2086]
@@ -520,7 +526,7 @@ prop_hereDocsAreParsedWithoutTrailingLinefeed = 1044 `elem` result
 
 prop_hereDocsWillHaveParsedIndices = null result
   where
-    result = check "#!/bin/bash\nreadonly my_array=(a b)\ncat <<EOF >> ./test\n $(( 1 + my_array[1] ))\nEOF"
+    result = check "#!/bin/bash\nmy_array=(a b)\ncat <<EOF >> ./test\n $(( 1 + my_array[1] ))\nEOF"
 
 prop_rcCanSuppressDfa = null result
   where

--- a/src/ShellCheck/Checker.hs
+++ b/src/ShellCheck/Checker.hs
@@ -359,7 +359,7 @@ prop_optionIncludes2 =
 
 prop_optionIncludes3 =
     -- expect 2086, no inclusions provided, so it is reported
-    [2086] == checkOptionIncludes Nothing "#!/bin/sh\n var='a b'\n echo $var"
+    [2086, 2331] == checkOptionIncludes Nothing "#!/bin/sh\n var='a b'\n echo $var"
 
 prop_optionIncludes4 =
     -- expect 2086 & 2154, only 2154 included, so only that's reported
@@ -520,7 +520,7 @@ prop_hereDocsAreParsedWithoutTrailingLinefeed = 1044 `elem` result
 
 prop_hereDocsWillHaveParsedIndices = null result
   where
-    result = check "#!/bin/bash\nmy_array=(a b)\ncat <<EOF >> ./test\n $(( 1 + my_array[1] ))\nEOF"
+    result = check "#!/bin/bash\nreadonly my_array=(a b)\ncat <<EOF >> ./test\n $(( 1 + my_array[1] ))\nEOF"
 
 prop_rcCanSuppressDfa = null result
   where


### PR DESCRIPTION
Adds an optional check for triggering a SC2331 for variables that are declared (and/or initialized) but never assigned to again. If a variable is found that matches, a note is given to maybe declare it as `readonly`.

Also implemented tests for it, as well as for the option itself in Checker.hs

Closes #2987 