### PR TITLE
Add python3 to the list of badShells

### DIFF
--- a/src/ShellCheck/Parser.hs
+++ b/src/ShellCheck/Parser.hs
@@ -3397,6 +3397,7 @@ readScriptFile sourced = do
         "fish",
         "perl",
         "python",
+        "python3",
         "ruby",
         "tcsh",
         "zsh"


### PR DESCRIPTION
My work environment has a some scripts that use python3 as the interpreter, not just /usr/bin/python.  Those scripts are mixed into the same directory as shell scripts.  None of these scripts, python, python3, or shell, contain a file extension to glob on.  There are specific reasons that some of these scripts use python vs python3, so changing the hashbang won't work for us.  Therefore, the smallest touch approach is to modify shellcheck to ignore files with python3 hashbangs.  I don't feel that this is a stretch or change of behavior since shellcheck already doesn't allow /usr/bin/python.