### PR TITLE
feat(formatter): add codeclimate formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - SC2332: Warn about `[ ! -o opt ]` being unconditionally true in Bash.
 - SC3062: Warn about bashism `[ -o opt ]`.
 - Precompiled binaries for Linux riscv64 (linux.riscv64)
+- Codeclimate: New Codeclimate formatter for GitLab Pipelines.
 ### Changed
 - SC2002 about Useless Use Of Cat is now disabled by default. It can be
   re-enabled with `--enable=useless-use-of-cat` or equivalent directive.

--- a/ShellCheck.cabal
+++ b/ShellCheck.cabal
@@ -89,6 +89,7 @@ library
       ShellCheck.Formatter.GCC
       ShellCheck.Formatter.JSON
       ShellCheck.Formatter.JSON1
+      ShellCheck.Formatter.Codeclimate
       ShellCheck.Formatter.TTY
       ShellCheck.Formatter.Quiet
       ShellCheck.Interface

--- a/shellcheck.hs
+++ b/shellcheck.hs
@@ -29,6 +29,7 @@ import qualified ShellCheck.Formatter.Diff
 import qualified ShellCheck.Formatter.GCC
 import qualified ShellCheck.Formatter.JSON
 import qualified ShellCheck.Formatter.JSON1
+import qualified ShellCheck.Formatter.Codeclimate
 import qualified ShellCheck.Formatter.TTY
 import qualified ShellCheck.Formatter.Quiet
 
@@ -155,6 +156,7 @@ formats options = Map.fromList [
     ("gcc",  ShellCheck.Formatter.GCC.format),
     ("json", ShellCheck.Formatter.JSON.format),
     ("json1", ShellCheck.Formatter.JSON1.format),
+    ("codeclimate", ShellCheck.Formatter.Codeclimate.format),
     ("tty",  ShellCheck.Formatter.TTY.format options),
     ("quiet",  ShellCheck.Formatter.Quiet.format options)
     ]

--- a/src/ShellCheck/Formatter/Codeclimate.hs
+++ b/src/ShellCheck/Formatter/Codeclimate.hs
@@ -1,0 +1,139 @@
+{-# LANGUAGE OverloadedStrings #-}
+module ShellCheck.Formatter.Codeclimate (format) where
+
+import ShellCheck.Interface
+import ShellCheck.Formatter.Format
+
+import Control.DeepSeq (deepseq)
+import Data.Aeson
+import Data.IORef
+import System.IO (hPutStrLn, stderr)
+import qualified Data.ByteString.Lazy.Char8 as BL
+import qualified Data.List.NonEmpty as NE
+import qualified Data.ByteString.Char8 as BS
+
+format :: IO Formatter
+format = do
+    ref <- newIORef []
+    return Formatter
+        { header    = return ()
+        , onResult  = collectResult ref
+        , onFailure = outputError
+        , footer    = finish ref
+        }
+
+data CCIssue = CCIssue
+  { description :: String
+  , check_name  :: String
+  , fingerprint :: String
+  , severity    :: String
+  , location    :: CCLocation
+  }
+
+data CCLocation = CCLocation
+  { path      :: String
+  , positions :: CCPositions
+  }
+
+data CCPositions = CCPositions
+  { begin :: CCPosition
+  , end   :: CCPosition
+  }
+
+data CCPosition = CCPosition
+  { line   :: Integer
+  , column :: Integer
+  }
+
+-- ToJSON instances
+instance ToJSON CCIssue where
+    toJSON issue = object
+      [ "type"        .= ("issue" :: String)
+      , "description" .= description issue
+      , "check_name"  .= check_name issue
+      , "fingerprint" .= fingerprint issue
+      , "severity"    .= severity issue
+      , "location"    .= location issue
+      ]
+    toEncoding issue = pairs
+      (  "type"        .= ("issue" :: String)
+      <> "description" .= description issue
+      <> "check_name"  .= check_name issue
+      <> "fingerprint" .= fingerprint issue
+      <> "severity"    .= severity issue
+      <> "location"    .= location issue
+      )
+
+instance ToJSON CCLocation where
+    toJSON loc = object
+      [ "path"      .= path loc
+      , "positions" .= positions loc
+      ]
+
+instance ToJSON CCPositions where
+    toJSON pos = object
+      [ "begin" .= begin pos
+      , "end"   .= end pos
+      ]
+
+instance ToJSON CCPosition where
+    toJSON p = object
+      [ "line"   .= line p
+      , "column" .= column p
+      ]
+
+-- Mapping ShellCheck PositionedComment -> CCIssue
+toCCIssue :: PositionedComment -> CCIssue
+toCCIssue pc =
+    let start        = pcStartPos pc
+        endPos       = pcEndPos pc
+        filePath     = posFile start
+        lineNum      = posLine start
+        endLineNum   = posLine endPos
+        columnNum    = posColumn start
+        endColumnNum = posColumn endPos
+        c            = pcComment pc
+        codeNum      = cCode c
+        msg          = cMessage c
+        desc = msg
+        checkName = "SC" ++ show codeNum
+        fingerprint = filePath ++ ":" ++ show lineNum ++ ":" ++ show codeNum
+        sevText = severityText pc
+        severityCC = mapSeverity sevText
+    in CCIssue
+         { description = desc
+         , check_name  = checkName
+         , fingerprint = fingerprint
+         , severity    = severityCC
+         , location    = CCLocation filePath (CCPositions (CCPosition lineNum columnNum) (CCPosition endLineNum endColumnNum))
+         }
+
+-- ShellCheck severity levels to Code Climate levels
+mapSeverity :: String -> String
+mapSeverity "error"   = "critical"
+mapSeverity "warning" = "major"
+mapSeverity "info"    = "minor"
+mapSeverity "style"   = "info"
+mapSeverity _         = "minor"
+
+outputError :: FilePath -> String -> IO ()
+outputError file msg = hPutStrLn stderr $ file ++ ": " ++ msg
+
+collectResult ref cr sys = mapM_ f groups
+  where
+    commentsAll = crComments cr
+    groups = NE.groupWith sourceFile commentsAll
+    f :: NE.NonEmpty PositionedComment -> IO ()
+    f group = do
+      let filename = sourceFile (NE.head group)
+      result <- siReadFile sys (Just True) filename
+      let contents = either (const "") id result
+      let comments' = makeNonVirtual commentsAll contents
+      deepseq comments' $ modifyIORef ref (\x -> comments' ++ x)
+
+finish :: IORef [PositionedComment] -> IO ()
+finish ref = do
+    pcs <- readIORef ref
+    let issues = map toCCIssue pcs
+    BL.putStrLn $ encode issues
+


### PR DESCRIPTION
This PR introduces a Codeclimate formatter. This is helpful when shellcheck is used inside a GitLab CI/CD Pipeline as it can be used to show a Code Quality report (https://docs.gitlab.com/ci/testing/code_quality/#view-code-quality-results)

<details>
<summary>The output of the formatter looks like this:</summary>

```json
[
  {
    "type": "issue",
    "description": "In POSIX sh, brace expansion is undefined.",
    "check_name": "SC3009",
    "fingerprint": "example.sh:2:3009",
    "severity": "major",
    "location": {
      "path": "example.sh",
      "positions": {
        "begin": {
          "column": 10,
          "line": 2
        },
        "end": {
          "column": 22,
          "line": 2
        }
      }
    }
  },
  {
    "type": "issue",
    "description": "In POSIX sh, RANDOM is undefined.",
    "check_name": "SC3028",
    "fingerprint": "example.sh:2:3028",
    "severity": "major",
    "location": {
      "path": "example.sh",
      "positions": {
        "begin": {
          "column": 14,
          "line": 2
        },
        "end": {
          "column": 21,
          "line": 2
        }
      }
    }
  },
  {
    "type": "issue",
    "description": "In POSIX sh, standalone ((..)) is undefined.",
    "check_name": "SC3006",
    "fingerprint": "example.sh:5:3006",
    "severity": "major",
    "location": {
      "path": "example.sh",
      "positions": {
        "begin": {
          "column": 6,
          "line": 5
        },
        "end": {
          "column": 22,
          "line": 5
        }
      }
    }
  },
  {
    "type": "issue",
    "description": "In POSIX sh, $[..] in place of $((..)) is undefined.",
    "check_name": "SC3007",
    "fingerprint": "example.sh:9:3007",
    "severity": "major",
    "location": {
      "path": "example.sh",
      "positions": {
        "begin": {
          "column": 8,
          "line": 9
        },
        "end": {
          "column": 14,
          "line": 9
        }
      }
    }
  },
  {
    "type": "issue",
    "description": "Use $((..)) instead of deprecated $[..]",
    "check_name": "SC2007",
    "fingerprint": "example.sh:9:2007",
    "severity": "info",
    "location": {
      "path": "example.sh",
      "positions": {
        "begin": {
          "column": 8,
          "line": 9
        },
        "end": {
          "column": 14,
          "line": 9
        }
      }
    }
  },
  {
    "type": "issue",
    "description": "In POSIX sh, == in place of = is undefined.",
    "check_name": "SC3014",
    "fingerprint": "example.sh:9:3014",
    "severity": "major",
    "location": {
      "path": "example.sh",
      "positions": {
        "begin": {
          "column": 15,
          "line": 9
        },
        "end": {
          "column": 17,
          "line": 9
        }
      }
    }
  },
  {
    "type": "issue",
    "description": "strbuzz is referenced but not assigned.",
    "check_name": "SC2154",
    "fingerprint": "example.sh:11:2154",
    "severity": "major",
    "location": {
      "path": "example.sh",
      "positions": {
        "begin": {
          "column": 10,
          "line": 11
        },
        "end": {
          "column": 18,
          "line": 11
        }
      }
    }
  },
  {
    "type": "issue",
    "description": "In POSIX sh, [[ ]] is undefined.",
    "check_name": "SC3010",
    "fingerprint": "example.sh:13:3010",
    "severity": "major",
    "location": {
      "path": "example.sh",
      "positions": {
        "begin": {
          "column": 6,
          "line": 13
        },
        "end": {
          "column": 18,
          "line": 13
        }
      }
    }
  }
]
```

</details>
<details>
<summary>Used example:</summary>

```sh
#!/bin/sh
for n in {1..$RANDOM}
do
  str=""
  if (( n % 3 == 0 ))
  then
    str="fizz"
  fi
  if [ $[n%5] == 0 ]
  then
    str="$strbuzz"
  fi
  if [[ ! $str ]]
  then
    str="$n"
  fi
  echo "$str"
done
```

</details>

The report can then be used with the following information in your GitLab CI/CD job:

```yaml
  artifacts:
    reports:
      codequality: sc-code-quality-report.json
```

I'll of course update the wiki accordingly when this PR gets merged.

- Resolves #3155 