### PR TITLE
Suggest removing null checks in parameter expansions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - SC2330: Warn about unsupported glob matches with [[ .. ]] in BusyBox.
 - SC2331: Suggest using standard -e instead of unary -a in tests.
 - SC2332: Warn about `[ ! -o opt ]` being unconditionally true in Bash.
+- SC2335: In parameter expansions, suggest replacing `:-`/`:=` with `-`/`=` when the substitution is empty.
 - SC3062: Warn about bashism `[ -o opt ]`.
 - Precompiled binaries for Linux riscv64 (linux.riscv64)
 ### Changed


### PR DESCRIPTION
${parameter-} expands to the empty string if parameter is unset. ${parameter:-} is a more verbose way of saying the same thing, because it expands to the empty string if parameter is unset or empty, and if parameter is empty, it merely replaces one empty with another.

Similarly, ${parameter=} assigns the empty string to parameter if parameter is unset, which is equivalent to what ${parameter:=} does, since assigning the empty string to a parameter already holding the empty string is a no-op.

(Of course, when the replacement to the right of the - or = is non-empty, there is a meaningful difference between the versions with and without the null-check colon.)