### PR TITLE
Use https:// for source-repository

### DIFF
--- a/ShellCheck.cabal
+++ b/ShellCheck.cabal
@@ -37,7 +37,7 @@ Extra-Source-Files:
 
 source-repository head
     type: git
-    location: git://github.com/koalaman/shellcheck.git
+    location: https://github.com/koalaman/shellcheck.git
 
 library
     hs-source-dirs: src


### PR DESCRIPTION
With Cabal >= 3.14, `cabal test` warns:

```
Warning: [git-protocol] Cloning over git:// might lead to an arbitrary code
execution vulnerability. Furthermore, popular forges like GitHub do not
support it. Use https:// or ssh:// instead.
```

https:// should work fine, so use that as suggested.