### PR TITLE
SC2183: Fix pluralization for zero arguments in printf format string

### DIFF
--- a/src/ShellCheck/Checks/Commands.hs
+++ b/src/ShellCheck/Checks/Commands.hs
@@ -691,7 +691,7 @@ checkPrintfVar = CommandCheck (Exactly "printf") (f . arguments) where
             let formats = getPrintfFormats string
             let formatCount = length formats
             let argCount = length more
-            let pluraliseIfMany word n = if n > 1 then word ++ "s" else word
+            let pluraliseIfMany word n = if n == 1 then word else word ++ "s"
 
             return $ if
                 | argCount == 0 && formatCount == 0 ->


### PR DESCRIPTION
Currently, [SC2183](https://www.shellcheck.net/wiki/SC2183) pluralizes "variable" and "argument" in the warning message when there are at least two variables/arguments, using the singular form for 1 of either (correct) or 0 of either (wrong):

```sh
#!/bin/sh
# Wrong usage:
printf 'Hello %s.\n'
printf 'Hello %s, and goodbye %s.\n'

# Correct usage:
world="world"
space="space"
printf 'Hello %s.\n' "${world}"
printf 'Hello %s, and goodbye %s.\n' "${space}" "${world}"
```

ShellCheck output on [shellcheck.net](https://www.shellcheck.net/):

```
Line 2:
printf 'Hello %s.\n'
       ^-- SC2183 (warning): This format string has 1 variable, but is passed 0 argument.
 
Line 3:
printf 'Hello %s, and goodbye %s.\n'
       ^-- SC2183 (warning): This format string has 2 variables, but is passed 0 argument.
```

This PR is a follow-up of the attempt in #2535 and ea4e009 to pluralize at all, (hopefully) fixing the last oversight.

(And yes, I switched the condition in the check, `let pluraliseIfMany word n = if n /= 1 then word ++ "s" else word` read weird to me...)