### PR TITLE
docs: update shellcheck precommit hook version to v0.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ To run ShellCheck via [pre-commit](https://pre-commit.com/), add the hook to you
 ```
 repos:
 -   repo: https://github.com/koalaman/shellcheck-precommit
-    rev: v0.7.2
+    rev: v0.11.0
     hooks:
     -   id: shellcheck
 #       args: ["--severity=warning"]  # Optionally only show errors and warnings


### PR DESCRIPTION
## What was done

Just using the current version from here: https://github.com/koalaman/shellcheck-precommit

I was going to perform a copy-past from the main README and then went to check for the existing pre-commit version.

Updating this to prevent such mistakes.