### PR TITLE
Fix JSON1 repeated comments across multiple files

### DIFF
--- a/src/ShellCheck/Formatter/JSON1.hs
+++ b/src/ShellCheck/Formatter/JSON1.hs
@@ -120,7 +120,7 @@ collectResult ref cr sys = mapM_ f groups
         let filename = sourceFile (NE.head group)
         result <- siReadFile sys (Just True) filename
         let contents = either (const "") id result
-        let comments' = makeNonVirtual comments contents
+        let comments' = makeNonVirtual (NE.toList group) contents
         deepseq comments' $ modifyIORef ref (\x -> comments' ++ x)
 
 finish ref = do


### PR DESCRIPTION
Fixes #3397.

Previously shellcheck would list all comments for each file. Now it only lists the comments which pertain to the file in question.