### PR TITLE
build: add missed default-language field to shellcheck-dev

### DIFF
--- a/ShellCheck.cabal
+++ b/ShellCheck.cabal
@@ -139,6 +139,7 @@ executable shellcheck-dev
       base,
       containers,
       ShellCheck
+    default-language: Haskell2010
     main-is: shellcheck-dev.hs
 
 test-suite test-shellcheck


### PR DESCRIPTION
> Warning: Packages using 'cabal-version: >= 1.10' and before 'cabal-version: 3.4' must specify the 'default-language' field for each component (e.g. Haskell98 or Haskell2010). If a component uses different languages in different modules then list the other ones in the 'other-languages' field.