### PR TITLE
Add --exclude-from=FILE flag with default to .shellcheckignore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Git
 ### Added
+- `--exclude-from` flag and default `.shellcheckignore` file to exclude files
+  matching glob patterns
 
 ### Changed
 

--- a/ShellCheck.cabal
+++ b/ShellCheck.cabal
@@ -162,7 +162,6 @@ test-suite test-shellcheck
       QuickCheck,
       regex-tdfa,
       transformers,
-      ShellCheck,
-      Glob
+      ShellCheck
     default-language: Haskell2010
     main-is: test/shellcheck.hs

--- a/ShellCheck.cabal
+++ b/ShellCheck.cabal
@@ -67,6 +67,7 @@ library
       QuickCheck           >= 2.14.2 && < 2.17,
       regex-tdfa           >= 1.2.0 && < 1.4,
       transformers         >= 0.4.2 && < 0.7,
+      Glob                 >= 0.9.0 && < 0.11,
 
       -- getXdgDirectory from 1.2.3.0
       directory            >= 1.2.3 && < 1.4
@@ -126,7 +127,8 @@ executable shellcheck
       QuickCheck,
       regex-tdfa,
       transformers,
-      ShellCheck
+      ShellCheck,
+      Glob
     default-language: Haskell2010
     main-is: shellcheck.hs
 
@@ -160,6 +162,7 @@ test-suite test-shellcheck
       QuickCheck,
       regex-tdfa,
       transformers,
-      ShellCheck
+      ShellCheck,
+      Glob
     default-language: Haskell2010
     main-is: test/shellcheck.hs

--- a/builders/linux.armv6hf/cabal.project.freeze
+++ b/builders/linux.armv6hf/cabal.project.freeze
@@ -1,5 +1,6 @@
 active-repositories: hackage.haskell.org:merge
 constraints: any.Diff ==1.0.2,
+             any.Glob ==0.10.2,
              any.OneTuple ==0.4.2,
              any.QuickCheck ==2.16.0.0,
              QuickCheck -old-random +templatehaskell,

--- a/shellcheck.1.md
+++ b/shellcheck.1.md
@@ -142,9 +142,14 @@ not warn at all, as `ksh` supports decimals in arithmetic contexts.
 **--exclude-from** *FILE*
 
 :   Exclude files matching glob patterns listed in *FILE*. Each line should
-    contain one glob pattern. Lines starting with `#` are ignored. If this
-    option is not specified, ShellCheck will look for a file named
-    `.shellcheckignore` in the current working directory and use it if present.
+    contain one glob pattern. Lines starting with `#` or empty lines are
+    ignored. A pattern is matched against the full file path, the file name,
+    and each parent directory. For example, the pattern `vendor` would exclude
+    any file with a `vendor` parent directory.
+
+    If this option is not specified, ShellCheck will search for a file named
+    `.shellcheckignore` in the current working directory and its parent
+    directories, the same way shellcheckrc is searched for.
 
 
 # FORMATS

--- a/shellcheck.1.md
+++ b/shellcheck.1.md
@@ -6,7 +6,7 @@ shellcheck - Shell script analysis tool
 
 # SYNOPSIS
 
-**shellcheck** [*OPTIONS*...] [--files-from=FILE] *FILES*...
+**shellcheck** [*OPTIONS*...] [--files-from=FILE] [--exclude-from=FILE] *FILES*...
 
 # DESCRIPTION
 
@@ -138,6 +138,13 @@ not warn at all, as `ksh` supports decimals in arithmetic contexts.
     file path. Lines starting with `#` or empty lines are ignored. Use `-` to
     read the list from standard input. This option is processed in addition to
     any files specified on the command line.
+
+**--exclude-from** *FILE*
+
+:   Exclude files matching glob patterns listed in *FILE*. Each line should
+    contain one glob pattern. Lines starting with `#` are ignored. If this
+    option is not specified, ShellCheck will look for a file named
+    `.shellcheckignore` in the current working directory and use it if present.
 
 
 # FORMATS

--- a/shellcheck.hs
+++ b/shellcheck.hs
@@ -54,6 +54,7 @@ import           System.Environment
 import           System.Exit
 import           System.FilePath
 import           System.IO
+import           System.FilePath.Glob            as Glob
 
 data Flag = Flag String String
 data Status =
@@ -137,7 +138,10 @@ options = [
         (NoArg $ Flag "help" "true") "Show this usage summary and exit",
     Option "" ["files-from"]
         (ReqArg (Flag "files-from") "FILE")
-        "Read input files from FILE (one per line, or '-' for stdin)"
+        "Read input files from FILE (one per line, or '-' for stdin)",
+    Option "X" ["exclude-from"]
+        (ReqArg (Flag "exclude-from") "FILE")
+        "Exclude files matching patterns listed in FILE, default .shellcheckignore"
     ]
 getUsageInfo = usageInfo usageHeader options
 
@@ -233,6 +237,20 @@ process flags files = do
     when (null filesFrom) $
         verifyFiles allFiles
 
+    -- Determine which ignore files to read (fallback to default if flag is omitted)
+    let explicitExcludeFrom = getOptions flags "exclude-from"
+    let excludeFrom = if null explicitExcludeFrom 
+                        then [".shellcheckignore"] 
+                        else explicitExcludeFrom
+
+    -- Silently skip missing files so the default fallback doesn't cause a crash
+    existingExcludes <- liftIO $ filterM doesFileExist excludeFrom
+    excludePatterns  <- fmap concat $ mapM readFilesFrom existingExcludes
+
+    -- Compile glob patterns and filter the input files
+    let compiledExcludes = map Glob.compile excludePatterns
+    let allFilteredFiles = filter (not . isExcludedFile compiledExcludes) allFiles
+
     let format = fromMaybe "tty" $ getOption flags "format"
     let formatters = formats $ formatterOptions options
     formatter <- case Map.lookup format formatters of
@@ -243,9 +261,9 @@ process flags files = do
             throwError SupportFailure
         Just f -> ExceptT $ fmap Right f
 
-    sys <- lift $ ioInterface options allFiles
+    sys <- lift $ ioInterface options allFilteredFiles
 
-    lift $ runFormatter sys formatter options allFiles
+    lift $ runFormatter sys formatter options allFilteredFiles
 
   where
     readFilesFrom :: FilePath -> ExceptT Status IO [FilePath]
@@ -262,7 +280,19 @@ process flags files = do
             Right contents ->
                 return (parseFileListLines contents)
 
+    isExcludedFile :: [Glob.Pattern] -> FilePath -> Bool
+    isExcludedFile patterns path = any matches patterns
+      where
+        matches pat =
+            Glob.match pat path ||
+            Glob.match pat (takeFileName path) ||
+            any (Glob.match pat) (ancestors path)
 
+        ancestors p =
+            let parent = takeDirectory p
+            in if parent == p || parent == "." || parent == "/"
+               then []
+               else parent : ancestors parent
 
 runFormatter :: SystemInterface IO -> Formatter -> Options -> [FilePath]
             -> IO Status
@@ -440,6 +470,9 @@ parseOption flag options =
 
         -- This flag is handled specially in 'process'
         Flag "files-from" _ -> return options
+
+        -- This flag is handled specially in 'process'
+        Flag "exclude-from" _ -> return options
 
         Flag str _ -> do
             printErr $ "Internal error for --" ++ str ++ ". Please file a bug :("
@@ -653,7 +686,6 @@ decodeString = decode
             then construct ((x `shiftL` 6) .|. (num .&. 0x3f)) (n-1) rest
             else Nothing
     construct _ _ _ = Nothing
-
 
 verifyFiles files =
     when (null files) $ do

--- a/shellcheck.hs
+++ b/shellcheck.hs
@@ -286,13 +286,7 @@ process flags files = do
         matches pat =
             Glob.match pat path ||
             Glob.match pat (takeFileName path) ||
-            any (Glob.match pat) (ancestors path)
-
-        ancestors p =
-            let parent = takeDirectory p
-            in if parent == p || parent == "." || parent == "/"
-               then []
-               else parent : ancestors parent
+            any (Glob.match pat) (splitDirectories path)
 
 runFormatter :: SystemInterface IO -> Formatter -> Options -> [FilePath]
             -> IO Status

--- a/shellcheck.hs
+++ b/shellcheck.hs
@@ -139,7 +139,7 @@ options = [
     Option "" ["files-from"]
         (ReqArg (Flag "files-from") "FILE")
         "Read input files from FILE (one per line, or '-' for stdin)",
-    Option "X" ["exclude-from"]
+    Option "" ["exclude-from"]
         (ReqArg (Flag "exclude-from") "FILE")
         "Exclude files matching patterns listed in FILE, default .shellcheckignore"
     ]


### PR DESCRIPTION
I've said I'll do it, so here it is.

Disclaimer, I'm not a Haskell Developer™, this has been done with the help of you know who.

Should fix #1996 #2011 #2258 #2411 #2859

To be clarified:

- [ ] It adds the Glob dependency, which I'm sure is not of the taste of everyone, suggestions are welcome.

- [ ] I wanted to add tests but it made the diff less readable, let me know if you think it's needed.

- [ ] I don't know the impact in term of performance, if someone has a test in mind let me know.

- [ ] I know that `.shellcheckignore` is not what everyone wants, but it has very little chance to conflict with anything so I made it default, can still remove it if really unwanted.