### PR TITLE
Fix crash on command substitution containing a sourced file

### DIFF
--- a/src/ShellCheck/Analytics.hs
+++ b/src/ShellCheck/Analytics.hs
@@ -5244,6 +5244,7 @@ checkExpansionWithRedirection params t =
             _ -> return ()
 
     checkCmd captureId (T_Redirecting _ redirs _) = foldr (walk captureId) (return ()) redirs
+    checkCmd _ _ = return ()
 
     walk captureId t acc =
         case t of

--- a/src/ShellCheck/Checker.hs
+++ b/src/ShellCheck/Checker.hs
@@ -352,6 +352,14 @@ prop_sourcedFileUsesOriginalShellExtension = result == [2079]
         csCheckSourced = True
     }
 
+prop_sourcedCommandInExpansionDoesntCrash = result == [2034]
+  where
+    result = checkWithSpec [("lib.sh", "echo hello")] emptyCheckSpec {
+        csFilename = "file.bash",
+        csScript = "x=$(source lib.sh)",
+        csCheckSourced = True
+    }
+
 prop_canEnableOptionalsWithSpec = result == [2244]
   where
     result = checkWithSpec [] emptyCheckSpec {


### PR DESCRIPTION
Fixes #3479.

With `--external-sources`, a command substitution whose last pipeline element resolves to a sourced file (e.g. `x=$(source lib.sh)`) makes `checkExpansionWithRedirection` call its local `checkCmd` with a `T_SourceCommand` rather than a `T_Redirecting`, and the single-clause `checkCmd` then aborts with "Non-exhaustive patterns in function checkCmd". This adds the missing catch-all so non-redirecting commands are simply ignored.