### PR TITLE
Record the command's id in CFSetExitCode for built-in handlers

### DIFF
--- a/src/ShellCheck/Analytics.hs
+++ b/src/ShellCheck/Analytics.hs
@@ -5097,6 +5097,8 @@ prop_checkOverwrittenExitCode5 = verify checkOverwrittenExitCode "x; if [ $? -eq
 prop_checkOverwrittenExitCode6 = verify checkOverwrittenExitCode "x; [ $? -gt 0 ] && fail=$?"
 prop_checkOverwrittenExitCode7 = verifyNot checkOverwrittenExitCode "[ 1 -eq 2 ]; status=$?"
 prop_checkOverwrittenExitCode8 = verifyNot checkOverwrittenExitCode "[ 1 -eq 2 ]; exit $?"
+prop_checkOverwrittenExitCode9 = verify checkOverwrittenExitCode "x; printf '%d' $?; [ $? -eq 0 ]"
+prop_checkOverwrittenExitCode10 = verifyNot checkOverwrittenExitCode "read -r x; [ $? -eq 0 ]"
 checkOverwrittenExitCode params t =
     case t of
         T_DollarBraced id _ val | getLiteralString val == Just "?" -> check id

--- a/src/ShellCheck/CFG.hs
+++ b/src/ShellCheck/CFG.hs
@@ -1196,7 +1196,7 @@ handleCommand cmd vars args literalCmd = do
 
             linkRanges $ [args] ++ assignments ++ [exe] ++ dropAssignments
 
-    regularExpansionWithStatus vars args@(cmd NE.:| _) p = do
+    regularExpansionWithStatus vars args p = do
         initial <- regularExpansion vars (NE.toList args) p
         status <- newNodeRange $ CFSetExitCode (getId cmd)
         linkRange initial status


### PR DESCRIPTION
Fixes #3490.

## Symptom

SC2320 fires for `echo` but not for `printf`:

```sh
#!/bin/sh
mycommand
printf 'Command exited with %d\n' $?
if [ $? -ne 0 ]      # no SC2320 here
then
  echo "Failed"
fi
```

A four-way probe puts the discriminator on the command name rather than on quoting:

| script | before | after |
|---|---|---|
| `printf '...%d' $?` | silent | SC2320 |
| `printf '...%d' "$?"` | silent | SC2320 |
| `echo "...$?"` | SC2320 | SC2320 |
| `echo $?` | SC2320 | SC2320 |

## Cause

`handleCommand cmd vars args literalCmd` receives the whole `T_SimpleCommand` as `cmd`, and the ordinary path registers the exit code against it:

```haskell
regular = handleOthers (getId cmd) vars args literalCmd
```

`regularExpansionWithStatus`, which the built-in table uses, shadows that name with the command's first *word*:

```haskell
regularExpansionWithStatus vars args@(cmd NE.:| _) p = do
    initial <- regularExpansion vars (NE.toList args) p
    status  <- newNodeRange $ CFSetExitCode (getId cmd)   -- id of the word, not the command
```

So `printf`, `unset`, `wait`, `mapfile`, `readarray`, `read` and the four `DEFINE_*` commands all register their exit code under the id of a `T_NormalWord`. A consumer that resolves that id through `idMap` then gets a word where it expects a command, and `checkOverwrittenExitCode` is exactly such a consumer: `getCommandBasename` is `Nothing` for a `T_NormalWord`, so `isPrinting` never matches. `echo` is not in the table, goes through `handleOthers`, and therefore works.

## Fix

Drop the shadowing pattern so `cmd` refers to the command again, matching `handleOthers`. One token; the body of the helper is unchanged.

## Tests

Two `prop_` cases next to the existing ones:

```haskell
prop_checkOverwrittenExitCode9  = verify    checkOverwrittenExitCode "x; printf '%d' $?; [ $? -eq 0 ]"
prop_checkOverwrittenExitCode10 = verifyNot checkOverwrittenExitCode "read -r x; [ $? -eq 0 ]"
```

The second pins the intended narrowness: `read` also goes through the helper and also gets a corrected id, but it is neither a condition nor a printing command, so nothing new is reported for it.

Verified on GHC 9.8.4:

- with the tests but *without* the fix, `cabal test` fails (`*** Failed! Falsified (after 1 test)`, `Test suite test-shellcheck: FAIL`);
- with the fix, `cabal test` passes in full;
- end-to-end per `CLAUDE.md`: the reporter's script now reports SC2320, `echo` is unchanged, and `mycommand; unset foo; [ $? -eq 0 ]` stays silent apart from the unrelated SC2181.

## AI usage

I used Claude to help trace the CFG path and to draft the patch and the two tests, following the workflow in this repository's `.claude/CLAUDE.md`. I read every line of the change, ran the four-way probe to establish the cause rather than assume it, ran the new tests against unpatched `master` first to confirm they fail without the fix, and ran the full `cabal test` and the end-to-end checks myself.