### PR TITLE
Treat compgen -V as assigning to an array

### DIFF
--- a/src/ShellCheck/Analytics.hs
+++ b/src/ShellCheck/Analytics.hs
@@ -2534,6 +2534,8 @@ prop_checkUnassignedReferences50 = verifyNotTree checkUnassignedReferences "echo
 prop_checkUnassignedReferences51 = verifyNotTree checkUnassignedReferences "echo ${foo:+$foo}"
 prop_checkUnassignedReferences52 = verifyNotTree checkUnassignedReferences "wait -p pid; echo $pid"
 prop_checkUnassignedReferences53 = verifyTree checkUnassignedReferences "x=($foo)"
+prop_checkUnassignedReferences54 = verifyNotTree checkUnassignedReferences "compgen -V files -G '*'; echo \"${files[@]}\""
+prop_checkUnassignedReferences55 = verifyNotTree checkUnassignedReferences "compgen -A function -V funcs; echo \"${funcs[@]}\""
 
 checkUnassignedReferences = checkUnassignedReferences' False
 checkUnassignedReferences' includeGlobals params t = warnings

--- a/src/ShellCheck/AnalyzerLib.hs
+++ b/src/ShellCheck/AnalyzerLib.hs
@@ -683,6 +683,7 @@ getModifiedVariableCommand base@(T_SimpleCommand id cmdPrefix (T_NormalWord _ (T
 
         "mapfile" -> maybeToList $ getMapfileArray base rest
         "readarray" -> maybeToList $ getMapfileArray base rest
+        "compgen" -> maybeToList $ getCompgenArray rest
 
         "DEFINE_boolean" -> maybeToList $ getFlagVariable rest
         "DEFINE_float" -> maybeToList $ getFlagVariable rest
@@ -741,6 +742,14 @@ getModifiedVariableCommand base@(T_SimpleCommand id cmdPrefix (T_NormalWord _ (T
 
     getPrintfVariable list = getFlagAssignedVariable "v" (SourceFrom list) $ getBsdOpts "v:" list
     getWaitVariable   list = getFlagAssignedVariable "p" SourceInteger     $ return $ getGenericOpts list
+
+    -- compgen -V arr stores the completions in the array arr rather than printing them
+    getCompgenArray list = do
+        flags <- getGnuOpts "abcdefgjksuvo:A:C:F:G:P:S:V:W:X:" list
+        (_, (_, value)) <- find ((== "V") . fst) flags
+        name <- getLiteralString value
+        guard $ isVariableName name
+        return (base, value, name, DataArray SourceExternal)
 
     getFlagAssignedVariable str dataSource maybeFlags = do
         flags <- maybeFlags


### PR DESCRIPTION
Fixes #3466.

## Symptom

`compgen -V arr` (bash 5.3) stores the completions in the array `arr` instead of printing them, but ShellCheck does not know that:

```sh
#!/bin/bash
compgen -V files -G '*'
printf "%s\n" "${files[@]}"
```

```
SC2154 (warning): files is referenced but not assigned.
```

The neighbouring forms are already handled — `mapfile -t files`, `readarray -t files` and `printf -v out` are all silent — so this is a gap in the table rather than a missing mechanism.

## Change

`getModifiedVariableCommand` gains a `compgen` entry next to `mapfile`/`readarray`, plus a helper shaped like the existing `getPrintfVariable`/`getWaitVariable` pair: parse the flags, take the argument of `-V`, and record it as `DataArray`.

The flag spec lists compgen's own options, so `-V` is found wherever it appears in the argument list, and a `compgen` call without `-V` records nothing.

## Tests

```haskell
prop_checkUnassignedReferences54 = verifyNotTree checkUnassignedReferences "compgen -V files -G '*'; echo \"${files[@]}\""
prop_checkUnassignedReferences55 = verifyNotTree checkUnassignedReferences "compgen -A function -V funcs; echo \"${funcs[@]}\""
```

The second covers `-V` arriving after another option. Both fail on `master` with the tests alone — `*** Failed! Falsified (after 1 test)` for exactly these two and nothing else — and pass with the change; the full `cabal test` suite is green on GHC 9.8.4.

End-to-end, per `CLAUDE.md`:

| script | result |
|---|---|
| `compgen -V files -G '*'` + `"${files[@]}"` | silent |
| `compgen -A function -V funcs` + `"${funcs[@]}"` | silent |
| `compgen -G '*'` (no `-V`) + `"${files[@]}"` | still SC2154 |
| `compgen -V files -G '*'` + `"${other[@]}"` | SC2154 for `other`, **and SC2034 for `files`** |
| `mapfile -t files` (control) | silent, unchanged |

The fourth row is the one I would check first as a reviewer: `files` now reports as *assigned but unused* rather than being silently ignored, which shows the variable is genuinely modelled as an assignment rather than the warning being suppressed.

## AI usage

I used Claude to help locate `getModifiedVariableCommand` and draft the helper and the tests, following this repository's `.claude/CLAUDE.md`. I reviewed every line, reproduced the warning first and confirmed that `mapfile`/`readarray`/`printf -v` already behave correctly so the fix would follow an existing shape, ran the new tests against unpatched `master` to confirm they fail, and ran the full test suite and the end-to-end table above myself.