### PR TITLE
Add `extended-analysis=local` to bound data-flow memory on large source trees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Git
 ### Added
+- `extended-analysis=local`: a new value for the `--extended-analysis` flag and
+  directive that performs dataflow analysis per file, treating sourced files as
+  opaque boundaries. This bounds memory when many checked files source a shared
+  tree of libraries, while keeping per-file dataflow checks (unlike `false`).
 
 ### Changed
 

--- a/shellcheck.1.md
+++ b/shellcheck.1.md
@@ -56,12 +56,17 @@ not warn at all, as `ksh` supports decimals in arithmetic contexts.
     options are cumulative, but all the codes can be specified at once,
     comma-separated as a single argument.
 
-**--extended-analysis=true/false**
+**--extended-analysis=true/local/false**
 
-:   Enable/disable Dataflow Analysis to identify more issues (default true). If
-    ShellCheck uses too much CPU/RAM when checking scripts with several
-    thousand lines of code, extended analysis can be disabled with this flag
-    or a directive. This flag overrides directives and rc files.
+:   Set the scope of Dataflow Analysis, which identifies more issues (default
+    true). `true` performs whole-program analysis, following data flow into
+    sourced files. `local` performs the analysis per file, treating sourced
+    files as opaque boundaries; this bounds memory when many checked files
+    source a shared tree of libraries (each includer would otherwise re-analyze
+    the whole tree), at the cost of data flow that crosses `source` boundaries.
+    `false` disables Dataflow Analysis entirely. Use `local` or `false` if
+    ShellCheck uses too much CPU/RAM. This flag overrides directives and rc
+    files.
 
 **-f** *FORMAT*, **--format=***FORMAT*
 
@@ -264,10 +269,13 @@ Valid keys are:
     Only file-wide `enable` directives are considered.
 
 **extended-analysis**
-:   Set to true/false to enable/disable dataflow analysis. Specifying
+:   Set to true/local/false to control dataflow analysis. `true` (default)
+    performs whole-program analysis; `local` performs it per file, treating
+    sourced files as opaque boundaries; `false` disables it. Specifying
     `# shellcheck extended-analysis=false` in particularly large (2000+ line)
     auto-generated scripts will reduce ShellCheck's resource usage at the
-    expense of certain checks. Extended analysis is enabled by default.
+    expense of certain checks. `local` bounds memory when many checked files
+    source a shared tree of libraries, while keeping per-file dataflow checks.
 
 **external-sources**
 :   Set to `true` in `.shellcheckrc` to always allow ShellCheck to open

--- a/shellcheck.hs
+++ b/shellcheck.hs
@@ -18,6 +18,7 @@
     along with this program.  If not, see <https://www.gnu.org/licenses/>.
 -}
 import qualified ShellCheck.Analyzer
+import           ShellCheck.AST (ExtendedAnalysisMode(..))
 import           ShellCheck.Checker
 import           ShellCheck.Data
 import           ShellCheck.Interface
@@ -103,7 +104,7 @@ options = [
     Option "e" ["exclude"]
         (ReqArg (Flag "exclude") "CODE1,CODE2..") "Exclude types of warnings",
     Option "" ["extended-analysis"]
-        (ReqArg (Flag "extended-analysis") "bool") "Perform dataflow analysis (default true)",
+        (ReqArg (Flag "extended-analysis") "mode") "Perform dataflow analysis: true|local|false (default true; local treats sourced files as boundaries)",
     Option "f" ["format"]
         (ReqArg (Flag "format") "FORMAT") $
         "Output format (" ++ formatList ++ ")",
@@ -428,7 +429,7 @@ parseOption flag options =
             }
 
         Flag "extended-analysis" str -> do
-            value <- parseBool str
+            value <- parseExtendedAnalysis str
             return options {
                 checkSpec = (checkSpec options) {
                     csExtendedAnalysis = Just value
@@ -461,6 +462,15 @@ parseOption flag options =
             "false" -> return False
             _ -> do
                 printErr $ "Invalid boolean, expected true/false: " ++ str
+                throwError SyntaxFailure
+
+    parseExtendedAnalysis str =
+        case str of
+            "true" -> return EAFull
+            "local" -> return EALocal
+            "false" -> return EAOff
+            _ -> do
+                printErr $ "Invalid extended-analysis value, expected true/local/false: " ++ str
                 throwError SyntaxFailure
 
 ioInterface :: Options -> [FilePath] -> IO (SystemInterface IO)

--- a/src/ShellCheck/AST.hs
+++ b/src/ShellCheck/AST.hs
@@ -153,8 +153,19 @@ data Annotation =
     | ShellOverride String
     | SourcePath String
     | ExternalSources Bool
-    | ExtendedAnalysis Bool
+    | ExtendedAnalysis ExtendedAnalysisMode
     deriving (Show, Eq)
+
+-- The scope of the data-flow ("extended") analysis, set via the
+-- `extended-analysis` directive/flag. Wire values: true=EAFull (default),
+-- false=EAOff, local=EALocal.
+data ExtendedAnalysisMode =
+    EAOff       -- No data-flow analysis.
+    | EALocal   -- Data-flow analysis within each file; sourced files are
+                -- treated as opaque boundaries (not inlined into the CFG).
+    | EAFull    -- Whole-program: data flow is followed into sourced files.
+    deriving (Show, Eq)
+
 data ConditionType = DoubleBracket | SingleBracket deriving (Show, Eq)
 
 pattern T_AND_IF id = OuterToken id Inner_T_AND_IF

--- a/src/ShellCheck/ASTLib.hs
+++ b/src/ShellCheck/ASTLib.hs
@@ -923,7 +923,7 @@ getEnableDirectives root =
         T_Annotation _ list _ -> [s | EnableComment s <- list]
         _ -> []
 
-getExtendedAnalysisDirective :: Token -> Maybe Bool
+getExtendedAnalysisDirective :: Token -> Maybe ExtendedAnalysisMode
 getExtendedAnalysisDirective root =
     case root of
         T_Annotation _ list _ -> listToMaybe $ [s | ExtendedAnalysis s <- list]

--- a/src/ShellCheck/AnalyzerLib.hs
+++ b/src/ShellCheck/AnalyzerLib.hs
@@ -204,7 +204,7 @@ makeCommentWithFix severity id code str fix =
 -- makeParameters :: CheckSpec -> Parameters
 makeParameters spec = params
   where
-    extendedAnalysis = fromMaybe True $ msum [asExtendedAnalysis spec, getExtendedAnalysisDirective root]
+    extendedAnalysisMode = fromMaybe EAFull $ msum [asExtendedAnalysis spec, getExtendedAnalysisDirective root]
     params = Parameters {
         rootNode = root,
         shellType = fromMaybe (determineShell (asFallbackShell spec) root) $ asShellType spec,
@@ -241,12 +241,16 @@ makeParameters spec = params
         variableFlow = getVariableFlow params root,
         tokenPositions = asTokenPositions spec,
         cfgAnalysis = do
-            guard extendedAnalysis
+            guard $ extendedAnalysisMode /= EAOff
             return $ CF.analyzeControlFlow cfParams root
     }
     cfParams = CF.CFGParameters {
         CF.cfLastpipe = hasLastpipe params,
-        CF.cfPipefail = hasPipefail params
+        CF.cfPipefail = hasPipefail params,
+        -- In 'local' mode, sourced files are data-flow boundaries: their
+        -- bodies are not inlined into the CFG (bounds memory on large
+        -- mutually-sourcing trees). See CFG.cfSourceAsBoundary.
+        CF.cfSourceAsBoundary = extendedAnalysisMode == EALocal
     }
     root = asScript spec
 

--- a/src/ShellCheck/CFG.hs
+++ b/src/ShellCheck/CFG.hs
@@ -168,7 +168,11 @@ data CFGParameters = CFGParameters {
     -- Whether the last element in a pipeline runs in the current shell
     cfLastpipe :: Bool,
     -- Whether all elements in a pipeline count towards the exit status
-    cfPipefail :: Bool
+    cfPipefail :: Bool,
+    -- Treat 'source'd files as data-flow boundaries: don't inline their
+    -- bodies into the CFG. Bounds memory when many inputs source a shared
+    -- tree (each includer would otherwise re-analyze the whole tree).
+    cfSourceAsBoundary :: Bool
 }
 
 data CFGResult = CFGResult {
@@ -871,11 +875,19 @@ build t = do
 
         T_SourceCommand _ originalCommand inlinedSource -> do
             cmd <- build originalCommand
-            end <- newStructuralNode
-            inline <- withReturn end $ build inlinedSource
-            linkRange cmd inline
-            linkRange inline end
-            return $ spanRange cmd inline
+            sourceAsBoundary <- reader $ cfSourceAsBoundary . cfParameters
+            if sourceAsBoundary
+              then
+                -- Data-flow boundary: do not inline the sourced body into the CFG.
+                -- Functions/vars it defines become opaque here; the file is
+                -- analyzed on its own when it is itself an input.
+                return cmd
+              else do
+                end <- newStructuralNode
+                inline <- withReturn end $ build inlinedSource
+                linkRange cmd inline
+                linkRange inline end
+                return $ spanRange cmd inline
 
         T_Subshell id body -> do
             main <- subshell id "explicit (..) subshell" $ sequentially body

--- a/src/ShellCheck/Checker.hs
+++ b/src/ShellCheck/Checker.hs
@@ -21,6 +21,7 @@
 module ShellCheck.Checker (checkScript, ShellCheck.Checker.runTests) where
 
 import ShellCheck.Analyzer
+import ShellCheck.AST (ExtendedAnalysisMode(..))
 import ShellCheck.ASTLib
 import ShellCheck.Interface
 import ShellCheck.Parser
@@ -561,14 +562,40 @@ prop_flagWinsWhenSuppressingDfa1 = result == [2317]
   where
     result = checkWithRc "extended-analysis=false" emptyCheckSpec {
         csScript = "#!/bin/sh\n# shellcheck extended-analysis=false\nexit; foo;",
-        csExtendedAnalysis = Just True
+        csExtendedAnalysis = Just EAFull
     }
 
 prop_flagWinsWhenSuppressingDfa2 = null result
   where
     result = checkWithRc "extended-analysis=true" emptyCheckSpec {
         csScript = "#!/bin/sh\n# shellcheck extended-analysis=true\nexit; foo;",
-        csExtendedAnalysis = Just False
+        csExtendedAnalysis = Just EAOff
+    }
+
+-- 'local' still does data-flow analysis within a file...
+prop_localKeepsIntraFileDfa = 2317 `elem` result
+  where
+    result = getErrors (mockedSystemInterface []) emptyCheckSpec {
+        csScript = "#!/bin/sh\nexit; foo;",
+        csExtendedAnalysis = Just EALocal
+    }
+
+-- ...but treats sourced files as boundaries, so it does not use data flow
+-- from a sourced file (here: that f() always exits) the way 'full' does.
+prop_localTreatsSourcesAsBoundary = 2317 `notElem` result
+  where
+    result = getErrors (mockedSystemInterface [("lib", "f() { exit 1; }")]) emptyCheckSpec {
+        csScript = "#!/bin/sh\nsource lib\nf\nfoo",
+        csCheckSourced = True,
+        csExtendedAnalysis = Just EALocal
+    }
+
+prop_fullFollowsDataFlowIntoSources = 2317 `elem` result
+  where
+    result = getErrors (mockedSystemInterface [("lib", "f() { exit 1; }")]) emptyCheckSpec {
+        csScript = "#!/bin/sh\nsource lib\nf\nfoo",
+        csCheckSourced = True,
+        csExtendedAnalysis = Just EAFull
     }
 
 return []

--- a/src/ShellCheck/Debug.hs
+++ b/src/ShellCheck/Debug.hs
@@ -117,7 +117,8 @@ dummySystemInterface = mockedSystemInterface [
 cfgParams :: CFGParameters
 cfgParams = CFGParameters {
     cfLastpipe = False,
-    cfPipefail = False
+    cfPipefail = False,
+    cfSourceAsBoundary = False
 }
 
 -- An example script to play with

--- a/src/ShellCheck/Interface.hs
+++ b/src/ShellCheck/Interface.hs
@@ -100,7 +100,7 @@ data CheckSpec = CheckSpec {
     csIncludedWarnings :: Maybe [Integer],
     csShellTypeOverride :: Maybe Shell,
     csMinSeverity :: Severity,
-    csExtendedAnalysis :: Maybe Bool,
+    csExtendedAnalysis :: Maybe ExtendedAnalysisMode,
     csOptionalChecks :: [String]
 } deriving (Show, Eq)
 
@@ -176,7 +176,7 @@ data AnalysisSpec = AnalysisSpec {
     asExecutionMode :: ExecutionMode,
     asCheckSourced :: Bool,
     asOptionalChecks :: [String],
-    asExtendedAnalysis :: Maybe Bool,
+    asExtendedAnalysis :: Maybe ExtendedAnalysisMode,
     asTokenPositions :: Map.Map Id (Position, Position)
 }
 

--- a/src/ShellCheck/Parser.hs
+++ b/src/ShellCheck/Parser.hs
@@ -1062,10 +1062,11 @@ readAnnotationWithoutPrefix sandboxed = do
                 pos <- getPosition
                 value <- plainOrQuoted $ many1 letter
                 case value of
-                    "true" -> return [ExtendedAnalysis True]
-                    "false" -> return [ExtendedAnalysis False]
+                    "true" -> return [ExtendedAnalysis EAFull]
+                    "local" -> return [ExtendedAnalysis EALocal]
+                    "false" -> return [ExtendedAnalysis EAOff]
                     _ -> do
-                        parseNoteAt pos ErrorC 1146 "Unknown extended-analysis value. Expected true/false."
+                        parseNoteAt pos ErrorC 1146 "Unknown extended-analysis value. Expected true/local/false."
                         return []
 
             "external-sources" -> do


### PR DESCRIPTION
## Summary

Adds a third value, `local`, to the existing `extended-analysis` option (flag, `.shellcheckrc`, and inline directive). It runs dataflow analysis **per file**, treating `source`'d files as opaque boundaries instead of inlining their bodies into the control-flow graph.

`extended-analysis` becomes a three-way scope control:

| Value | Dataflow analysis | Sourced files |
|-------|-------------------|---------------|
| `true` (default) | whole-program | inlined into the control-flow graph (data flow followed across `source`) |
| `local` (new) | per file | opaque boundary (defined functions/vars treated as unknown at the call site) |
| `false` | none | (n/a) |

All three still *follow* sources for parsing and AST-level checks (variable resolution, [SC2154](https://www.shellcheck.net/wiki/SC2154), etc.), they differ only in how far the data-flow pass reaches.

`true`/`false` are unchanged and fully backward compatible.

## Motivation

ShellCheck's whole-program iterative dataflow analysis can consume a great deal of memory on large graphs. The worst case is a set of scripts that each `source` a shared tree of libraries and are all checked in one invocation: every includer re-inlines the entire sourced tree into its own control-flow graph, and the context-sensitive fixpoint (which retains per-call-path state) then runs over that multiplied graph. Memory grows super-linearly with graph size.

This is the situation described in #3177 and #3442. The current escape hatch is `extended-analysis=false`, which throws out *all* dataflow checks. `local` is a middle ground: it keeps per-file dataflow analysis (so intra-file checks such as [SC2317](https://www.shellcheck.net/wiki/SC2317) still fire) while removing the cross-file multiplication that drives the blow-up.

## What changes for users

- New value: `--extended-analysis=local`, `extended-analysis=local` in `.shellcheckrc`, and `# shellcheck extended-analysis=local` inline.
- `local` keeps dataflow checks that are decidable within a single file.
- `local` gives up dataflow that crosses a `source` boundary. Concretely, it won't use knowledge from a sourced file (e.g. "this sourced function always exits", "this sourced variable is always an integer") the way `true` does. Compared to `true` this can mean a few fewer/extra findings around cross-source data flow. Compared to `false` it is strictly more analysis.

## Evidence

A real ~200-file project (many scripts sourcing files from a shared library tree), whole-tree invocation:

| Mode | Peak RSS | Findings |
|------|----------|----------|
| `true` | 2031 MiB | 85 |
| `local` | 834 MiB | 81 |
| `false` | 387 MiB | 80 |

On that project `local` roughly halves peak memory versus `true`. The 4-finding delta is cross-source dataflow that `true` resolves via inlining.

## Review note / open question

I chose `local` as a new additional value (single lowercase word, matching existing directive-value conventions) to keep the change minimal. A fully-named triad would probably be more consistent, though (e.g. `none`/`local`/`full` with `true`/`false` kept as backwards-compatible aliases). Open for discussion.