### PR TITLE
Don't report SC2218 when another definition's order is unknown

### DIFF
--- a/src/ShellCheck/Analytics.hs
+++ b/src/ShellCheck/Analytics.hs
@@ -3901,6 +3901,8 @@ prop_checkUseBeforeDefinition3 = verifyNotTree checkUseBeforeDefinition "if ! my
 prop_checkUseBeforeDefinition4 = verifyNotTree checkUseBeforeDefinition "mycmd || mycmd() { f; }"
 prop_checkUseBeforeDefinition5 = verifyTree checkUseBeforeDefinition "false || mycmd; mycmd() { f; }"
 prop_checkUseBeforeDefinition6 = verifyNotTree checkUseBeforeDefinition "f() { one; }; f; f() { two; }; f"
+prop_checkUseBeforeDefinition7 = verifyNotTree checkUseBeforeDefinition "setup() { f() { true; }; }; f; f() { true; }"
+prop_checkUseBeforeDefinition8 = verifyNotTree checkUseBeforeDefinition "#!/usr/bin/env bats\nsetup() { f() { true; }; }\n@test \"a\" {\n  f\n}\n@test \"b\" {\n  f() { true; }\n}"
 checkUseBeforeDefinition :: Parameters -> Token -> [TokenComment]
 checkUseBeforeDefinition params t = fromMaybe [] $ do
     cfga <- cfgAnalysis params
@@ -3920,7 +3922,10 @@ checkUseBeforeDefinition params t = fromMaybe [] $ do
                 name <- getLiteralString cmd
                 invocations <- Map.lookup name funcs
                 -- Is the function definitely being defined later?
-                guard $ any (\c -> CF.doesPostDominate cfga c id) invocations
+                -- Every definition has to be later: one whose order we can't
+                -- determine, such as in a function nothing visibly invokes,
+                -- may already have run.
+                guard $ all (\c -> CF.doesPostDominate cfga c id) invocations
                 -- Was one already defined, so it's actually a re-definition?
                 guard . not $ any (\c -> CF.doesPostDominate cfga id c) invocations
                 return $ err id 2218 "This function is only defined later. Move the definition up."


### PR DESCRIPTION
Fixes #3509.

### Minimal reproduction

The report says the case could not be shrunk below the 1069-line real library. It does reduce, and neither `source` nor bats is needed:

```sh
setup() { f() { true; }; }
f
f() { true; }
```

```
In t.sh line 2:
f
^-- SC2218 (error): This function is only defined later. Move the definition up.
```

The reported shape, with nothing sourced:

```sh
#!/usr/bin/env bats
setup() { f() { true; }; }
@test "a" {
  f
}
@test "b" {
  f() { true; }
}
```

### Cause

`checkUseBeforeDefinition` warns when *some* definition post-dominates the call and *no* definition is post-dominated by it. Here there are two definitions: one inside `setup`'s body, one at top level after the call. The top-level one satisfies the first guard; the one in `setup` satisfies neither relation, because nothing in the script visibly calls `setup`. So the check concludes "only defined later" while a definition whose order it cannot determine is sitting right there.

That definition may well have run. bats calls `setup` before every `@test`, and in an ordinary script a function can be reached through a trap, an indirect call, or a sourcing parent. SC2218 is an error, whereas SC2329 ("This function is never invoked") is only an info, hedged with "or ignored if invoked indirectly", for exactly that reason.

### Change

Require *every* definition to come after the call rather than just one. The second guard stays as it is: inside a loop a definition can both post-dominate the call and be post-dominated by it.

The true positives are unaffected: `prop_checkUseBeforeDefinition1` and `5` still fire, `2`, `3`, `4` and `6` still don't. Two props are added for the two shapes above. Both fail on master and pass with the change, and `cabal test` is green.

The reporter's original case, with their `betteropts.sh`, goes from the SC2218 above to exit 0.